### PR TITLE
Doc update

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ Aerospike Prometheus Exporter can be compiled and built from the source [aerospi
     # key file
     key_file=""
 
+    # Passphrase for encrypted key_file. Supports below formats,
+    # 1. Passphrase directly                 - "<passphrase>"
+    # 2. Passphrase via file                 - "file:<file-that-contains-passphrase>"
+    # 3. Passphrase via environment variable - "env:<environment-variable-that-holds-passphrase>"
+    key_file_passphrase=""
+
     # node TLS name for authentication
     node_tls_name=""
 
@@ -174,6 +180,14 @@ Aerospike Prometheus Exporter can be compiled and built from the source [aerospi
     "cluster_size",
     "batch_index_*",
     "xdr_ship_*"
+    ]
+
+    # XDR metrics whitelist (only for server versions 5.0 and above)
+    xdr_metrics_whitelist=[
+    "success",
+    "latency_ms",
+    "throughput",
+    "lap_us"
     ]
     ```
 


### PR DESCRIPTION
- [PROD-993] & [PROD-1045] - Update README for exporter's `xdr_metrics_whitelist` and `key_file_passphrase` configs

[PROD-993]: https://aerospike.atlassian.net/browse/PROD-993
[PROD-1045]: https://aerospike.atlassian.net/browse/PROD-1045