### PR TITLE
Correct 90 percentile latency computation on grafana latency dashboard

### DIFF
--- a/config/grafana/dashboards/latency.json
+++ b/config/grafana/dashboards/latency.json
@@ -215,7 +215,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.9,rate(aerospike_latencies_${operation}_${latencytimeunit}_bucket{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "histogram_quantile(0.9,aerospike_latencies_${operation}_${latencytimeunit}_bucket{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
           "legendFormat": "{{service}}/{{ns}}",
           "refId": "A"
         }


### PR DESCRIPTION
The aerospike_latencies_${operation}_${latencytimeunit}_bucket metrics is an ops/sec gauge
so we don't need to apply a rate on it