### PR TITLE
[TOOLS-2070] Use rate with latency quantile.

### DIFF
--- a/config/grafana/dashboards/latency.json
+++ b/config/grafana/dashboards/latency.json
@@ -213,7 +213,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.9,aerospike_latencies_${operation}_${latencytimeunit}_bucket{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
+          "expr": "histogram_quantile(0.9, rate(aerospike_latencies_${operation}_${latencytimeunit}_bucket{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "legendFormat": "{{service}}/{{ns}}",
           "refId": "A"
         }


### PR DESCRIPTION
Use rate() before taking the histogram_quantile for the latency quantile panels.