### PR TITLE
[TOOLS-2069] Add batch-index latency panels.

### DIFF
--- a/config/grafana/dashboards/latency.json
+++ b/config/grafana/dashboards/latency.json
@@ -365,7 +365,7 @@
           "refId": "Aerospike Prometheus-operation-Variable-Query"
         },
         "refresh": 2,
-        "regex": "/.*aerospike_latencies_(((s|p)i_[a-z]*)|([a-z]*))_[a-z]*_count/",
+        "regex": "/.*aerospike_latencies_((((s|p)i_[a-z]*)|([a-z]*))[_a-z]*)_[a-z]*_count/",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",


### PR DESCRIPTION
Support batch-index bucket and count metrics. EX: aerospike_latencies_batch_index_us_bucket and aerospike_latencies_batch_index_us_count