### PR TITLE
feat: added job_name variable to grafana dashboards

### DIFF
--- a/config/grafana/dashboards/alerts.json
+++ b/config/grafana/dashboards/alerts.json
@@ -283,7 +283,7 @@
       ],
       "targets": [
         {
-          "expr": "ALERTS{job=\"aerospike\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\", severity=~\"$severity|$^\", alertstate=~\"$state|$^\",}",
+          "expr": "ALERTS{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\", severity=~\"$severity|$^\", alertstate=~\"$state|$^\",}",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -307,7 +307,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+        "definition": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -317,7 +317,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+          "query": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
           "refId": "Aerospike Prometheus-cluster-Variable-Query"
         },
         "refresh": 2,
@@ -334,7 +334,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_stats_uptime{job=\"aerospike\", cluster_name=~\"$cluster|$^\"},service)",
+        "definition": "label_values(aerospike_node_stats_uptime{job=\"$job_name\", cluster_name=~\"$cluster|$^\"},service)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -344,7 +344,7 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_stats_uptime{job=\"aerospike\", cluster_name=~\"$cluster|$^\"},service)",
+          "query": "label_values(aerospike_node_stats_uptime{job=\"$job_name\", cluster_name=~\"$cluster|$^\"},service)",
           "refId": "Aerospike Prometheus-node-Variable-Query"
         },
         "refresh": 2,
@@ -469,6 +469,33 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "aerospike",
+          "value": "aerospike"
+        },
+        "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
+        "definition": "label_values(aerospike_node_stats_uptime,job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job_name",
+        "multi": false,
+        "name": "job_name",
+        "options": [],
+        "query": {
+          "query": "label_values(aerospike_node_stats_uptime,job)",
+          "refId": "Aerospike Prometheus-job-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },

--- a/config/grafana/dashboards/cluster.json
+++ b/config/grafana/dashboards/cluster.json
@@ -91,7 +91,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "min(aerospike_node_stats_uptime{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
+          "expr": "min(aerospike_node_stats_uptime{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -161,7 +161,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "sum(aerospike_node_up{job=\"aerospike\", cluster_name=~\"$cluster\"})",
+          "expr": "sum(aerospike_node_up{job=\"$job_name\", cluster_name=~\"$cluster\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -233,7 +233,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_stop_writes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
+          "expr": "sum(aerospike_namespace_stop_writes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -305,7 +305,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_migrate_rx_partitions_remaining{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) + sum(aerospike_namespace_migrate_tx_partitions_remaining{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
+          "expr": "sum(aerospike_namespace_migrate_rx_partitions_remaining{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) + sum(aerospike_namespace_migrate_tx_partitions_remaining{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -366,7 +366,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "aerospike_node_up{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_node_up{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -445,7 +445,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "count(ALERTS{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
+          "expr": "count(ALERTS{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -517,7 +517,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_clock_skew_stop_writes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
+          "expr": "sum(aerospike_namespace_clock_skew_stop_writes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -581,7 +581,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_unavailable_partitions{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
+          "expr": "sum(aerospike_namespace_unavailable_partitions{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -590,7 +590,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(aerospike_namespace_dead_partitions{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
+          "expr": "sum(aerospike_namespace_dead_partitions{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -659,7 +659,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_read_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_read_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -668,14 +668,14 @@
           "refId": "B"
         },
         {
-          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_read_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_read_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{cluster_name}}: Successful",
           "refId": "A"
         },
         {
-          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_read_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_read_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -684,7 +684,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_read_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_read_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -693,7 +693,7 @@
           "refId": "D"
         },
         {
-          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_read_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_read_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -799,21 +799,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_write_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_write_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_write_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_write_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_write_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_write_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{cluster_name}}: Total",
           "refId": "B"
         },
         {
-          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_write_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_write_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{cluster_name}}: Successful",
           "refId": "A"
         },
         {
-          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_write_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_write_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -821,7 +821,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_write_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name) (rate(aerospike_namespace_client_write_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{cluster_name}}: Error",
@@ -939,7 +939,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_node_stats_client_connections{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_node_stats_client_connections{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1046,7 +1046,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_node_stats_cluster_size{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_node_stats_cluster_size{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1166,7 +1166,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_node_stats_heap_active_kbytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_node_stats_heap_active_kbytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1272,7 +1272,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_node_stats_heap_allocated_kbytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_node_stats_heap_allocated_kbytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1378,7 +1378,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_node_stats_heap_mapped_kbytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_node_stats_heap_mapped_kbytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1484,7 +1484,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_node_stats_heap_efficiency_pct{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_node_stats_heap_efficiency_pct{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1590,7 +1590,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_node_stats_system_free_mem_pct{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_node_stats_system_free_mem_pct{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1710,7 +1710,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_node_stats_process_cpu_pct{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_node_stats_process_cpu_pct{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1816,7 +1816,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_node_stats_system_total_cpu_pct{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_node_stats_system_total_cpu_pct{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1922,7 +1922,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_node_stats_system_kernel_cpu_pct{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_node_stats_system_kernel_cpu_pct{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2028,7 +2028,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_node_stats_system_user_cpu_pct{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_node_stats_system_user_cpu_pct{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2134,7 +2134,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+        "definition": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2144,7 +2144,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+          "query": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
           "refId": "Aerospike Prometheus-cluster-Variable-Query"
         },
         "refresh": 2,
@@ -2161,7 +2161,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_stats_uptime{job=\"aerospike\", cluster_name=~\"$cluster|$^\"},service)",
+        "definition": "label_values(aerospike_node_stats_uptime{job=\"$job_name\", cluster_name=~\"$cluster|$^\"},service)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2171,7 +2171,7 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_stats_uptime{job=\"aerospike\", cluster_name=~\"$cluster|$^\"},service)",
+          "query": "label_values(aerospike_node_stats_uptime{job=\"$job_name\", cluster_name=~\"$cluster|$^\"},service)",
           "refId": "Aerospike Prometheus-node-Variable-Query"
         },
         "refresh": 2,
@@ -2188,7 +2188,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_namespace_objects{job=\"aerospike\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
+        "definition": "label_values(aerospike_namespace_objects{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2198,7 +2198,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_namespace_objects{job=\"aerospike\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
+          "query": "label_values(aerospike_namespace_objects{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
           "refId": "Aerospike Prometheus-namespace-Variable-Query"
         },
         "refresh": 2,
@@ -2230,6 +2230,33 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "aerospike",
+          "value": "aerospike"
+        },
+        "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
+        "definition": "label_values(aerospike_node_stats_uptime,job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job_name",
+        "multi": false,
+        "name": "job_name",
+        "options": [],
+        "query": {
+          "query": "label_values(aerospike_node_stats_uptime,job)",
+          "refId": "Aerospike Prometheus-job-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },

--- a/config/grafana/dashboards/exporters.json
+++ b/config/grafana/dashboards/exporters.json
@@ -106,7 +106,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "up{job=\"aerospike\"}",
+          "expr": "up{job=\"$job_name\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -166,6 +166,33 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "aerospike",
+          "value": "aerospike"
+        },
+        "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
+        "definition": "label_values(aerospike_node_stats_uptime,job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job_name",
+        "multi": false,
+        "name": "job_name",
+        "options": [],
+        "query": {
+          "query": "label_values(aerospike_node_stats_uptime,job)",
+          "refId": "Aerospike Prometheus-job-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },

--- a/config/grafana/dashboards/jobs.json
+++ b/config/grafana/dashboards/jobs.json
@@ -137,7 +137,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "aerospike_jobs_job_progress{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"}",
+          "expr": "aerospike_jobs_job_progress{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"}",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -202,7 +202,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_jobs_n_pids_requested{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
+          "expr": "sum(aerospike_jobs_n_pids_requested{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -262,7 +262,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_jobs_rps{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
+          "expr": "sum(aerospike_jobs_rps{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -322,7 +322,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_jobs_active_threads{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
+          "expr": "sum(aerospike_jobs_active_threads{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -384,7 +384,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "min(aerospike_jobs_job_progress{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
+          "expr": "min(aerospike_jobs_job_progress{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -444,7 +444,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "max(aerospike_jobs_run_time{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
+          "expr": "max(aerospike_jobs_run_time{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -504,7 +504,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "max(aerospike_jobs_time_since_done{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
+          "expr": "max(aerospike_jobs_time_since_done{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -564,7 +564,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_jobs_recs_throttled{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
+          "expr": "sum(aerospike_jobs_recs_throttled{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -624,7 +624,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_jobs_recs_filtered_meta{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
+          "expr": "sum(aerospike_jobs_recs_filtered_meta{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -634,7 +634,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(aerospike_jobs_recs_filtered_bins{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
+          "expr": "sum(aerospike_jobs_recs_filtered_bins{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -725,7 +725,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_jobs_recs_failed{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
+          "expr": "sum(aerospike_jobs_recs_failed{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -735,7 +735,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(aerospike_jobs_recs_succeeded{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
+          "expr": "sum(aerospike_jobs_recs_succeeded{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -795,7 +795,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_jobs_net_io_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
+          "expr": "sum(aerospike_jobs_net_io_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -855,7 +855,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "max(aerospike_jobs_socket_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
+          "expr": "max(aerospike_jobs_socket_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", set=~\"$set\", trid=~\"$job_id\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -898,7 +898,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+        "definition": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -908,7 +908,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+          "query": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -925,7 +925,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_namespace_objects{job=\"aerospike\", cluster_name=~\"$cluster|$^\" },ns)",
+        "definition": "label_values(aerospike_namespace_objects{job=\"$job_name\", cluster_name=~\"$cluster|$^\" },ns)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -935,7 +935,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_namespace_objects{job=\"aerospike\", cluster_name=~\"$cluster|$^\" },ns)",
+          "query": "label_values(aerospike_namespace_objects{job=\"$job_name\", cluster_name=~\"$cluster|$^\" },ns)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -952,7 +952,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_sets_objects{job=\"aerospike\", cluster_name=~\"$cluster|$^\", ns=~\"$namespace|$^\" },set)",
+        "definition": "label_values(aerospike_sets_objects{job=\"$job_name\", cluster_name=~\"$cluster|$^\", ns=~\"$namespace|$^\" },set)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -962,7 +962,7 @@
         "name": "set",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_sets_objects{job=\"aerospike\", cluster_name=~\"$cluster|$^\", ns=~\"$namespace|$^\" },set)",
+          "query": "label_values(aerospike_sets_objects{job=\"$job_name\", cluster_name=~\"$cluster|$^\", ns=~\"$namespace|$^\" },set)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -979,7 +979,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_jobs_job_progress{job=\"aerospike\", cluster_name=~\"$cluster|$^\", ns=~\"$namespace|$^\", set=~\"$set|$^\" },trid)",
+        "definition": "label_values(aerospike_jobs_job_progress{job=\"$job_name\", cluster_name=~\"$cluster|$^\", ns=~\"$namespace|$^\", set=~\"$set|$^\" },trid)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -989,7 +989,7 @@
         "name": "job_id",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_jobs_job_progress{job=\"aerospike\", cluster_name=~\"$cluster|$^\", ns=~\"$namespace|$^\", set=~\"$set|$^\" },trid)",
+          "query": "label_values(aerospike_jobs_job_progress{job=\"$job_name\", cluster_name=~\"$cluster|$^\", ns=~\"$namespace|$^\", set=~\"$set|$^\" },trid)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -998,6 +998,33 @@
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "aerospike",
+          "value": "aerospike"
+        },
+        "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
+        "definition": "label_values(aerospike_node_stats_uptime,job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job_name",
+        "multi": false,
+        "name": "job_name",
+        "options": [],
+        "query": {
+          "query": "label_values(aerospike_node_stats_uptime,job)",
+          "refId": "Aerospike Prometheus-job-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",
         "useTags": false

--- a/config/grafana/dashboards/latency.json
+++ b/config/grafana/dashboards/latency.json
@@ -192,7 +192,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (le) (aerospike_latencies_${operation}_${latencytimeunit}_bucket{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"})",
+          "expr": "sum by (le) (aerospike_latencies_${operation}_${latencytimeunit}_bucket{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"})",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -261,7 +261,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+        "definition": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -271,7 +271,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+          "query": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
           "refId": "Aerospike Prometheus-cluster-Variable-Query"
         },
         "refresh": 2,
@@ -288,7 +288,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_stats_uptime{job=\"aerospike\", cluster_name=~\"$cluster|$^\"},service)",
+        "definition": "label_values(aerospike_node_stats_uptime{job=\"$job_name\", cluster_name=~\"$cluster|$^\"},service)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -298,7 +298,7 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_stats_uptime{job=\"aerospike\", cluster_name=~\"$cluster|$^\"},service)",
+          "query": "label_values(aerospike_node_stats_uptime{job=\"$job_name\", cluster_name=~\"$cluster|$^\"},service)",
           "refId": "Aerospike Prometheus-node-Variable-Query"
         },
         "refresh": 2,
@@ -315,7 +315,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_namespace_objects{job=\"aerospike\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
+        "definition": "label_values(aerospike_namespace_objects{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -325,7 +325,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_namespace_objects{job=\"aerospike\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
+          "query": "label_values(aerospike_namespace_objects{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
           "refId": "Aerospike Prometheus-namespace-Variable-Query"
         },
         "refresh": 2,
@@ -412,6 +412,33 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "aerospike",
+          "value": "aerospike"
+        },
+        "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
+        "definition": "label_values(aerospike_node_stats_uptime,job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job_name",
+        "multi": false,
+        "name": "job_name",
+        "options": [],
+        "query": {
+          "query": "label_values(aerospike_node_stats_uptime,job)",
+          "refId": "Aerospike Prometheus-job-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },

--- a/config/grafana/dashboards/namespace.json
+++ b/config/grafana/dashboards/namespace.json
@@ -1618,7 +1618,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(aerospike_namespace_client_read_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_client_read_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1627,14 +1627,14 @@
           "refId": "B"
         },
         {
-          "expr": "rate(aerospike_namespace_client_read_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_client_read_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{service}}/{{ns}}: Successful",
           "refId": "A"
         },
         {
-          "expr": "rate(aerospike_namespace_client_read_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_client_read_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1643,7 +1643,7 @@
           "refId": "C"
         },
         {
-          "expr": "rate(aerospike_namespace_client_read_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_client_read_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1652,7 +1652,7 @@
           "refId": "D"
         },
         {
-          "expr": "rate(aerospike_namespace_client_read_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_client_read_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1756,21 +1756,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(aerospike_namespace_client_write_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_write_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_write_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_client_write_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_write_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_write_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{service}}/{{ns}}: Total",
           "refId": "B"
         },
         {
-          "expr": "rate(aerospike_namespace_client_write_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_client_write_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{service}}/{{ns}}: Successful",
           "refId": "A"
         },
         {
-          "expr": "rate(aerospike_namespace_client_write_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_client_write_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1778,7 +1778,7 @@
           "refId": "C"
         },
         {
-          "expr": "rate(aerospike_namespace_client_write_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_client_write_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{service}}/{{ns}}: Error",
@@ -1896,7 +1896,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(aerospike_namespace_batch_sub_read_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_delete_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_udf_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_batch_sub_read_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_delete_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_udf_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1905,7 +1905,7 @@
           "refId": "B"
         },
         {
-          "expr": "rate(aerospike_namespace_batch_sub_read_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_delete_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_udf_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_batch_sub_read_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_delete_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_udf_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1914,7 +1914,7 @@
           "refId": "C"
         },
         {
-          "expr": "rate(aerospike_namespace_batch_sub_read_filtered_out{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_filtered_out{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_delete_filtered_out{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_udf_filtered_out{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_batch_sub_read_filtered_out{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_filtered_out{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_delete_filtered_out{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_udf_filtered_out{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1923,7 +1923,7 @@
           "refId": "E"
         },
         {
-          "expr": "rate(aerospike_namespace_batch_sub_read_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_delete_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_udf_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_batch_sub_read_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_delete_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_udf_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1932,7 +1932,7 @@
           "refId": "D"
         },
         {
-          "expr": "rate(aerospike_namespace_batch_sub_read_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_delete_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_udf_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_batch_sub_read_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_delete_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_udf_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "legendFormat": "{{service}}/{{ns}}: Timeout",
           "refId": "A"
         }
@@ -2035,7 +2035,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(aerospike_namespace_pi_query_long_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_aggr_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_udf_bg_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_ops_bg_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_long_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_aggr_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_udf_bg_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_ops_bg_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_pi_query_long_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_aggr_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_udf_bg_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_ops_bg_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_long_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_aggr_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_udf_bg_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_ops_bg_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2045,7 +2045,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(aerospike_namespace_pi_query_long_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_aggr_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_udf_bg_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_ops_bg_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_long_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_aggr_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_udf_bg_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_ops_bg_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_pi_query_long_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_aggr_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_udf_bg_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_ops_bg_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_long_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_aggr_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_udf_bg_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_ops_bg_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2056,7 +2056,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(aerospike_namespace_pi_query_long_basic_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_aggr_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_udf_bg_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_ops_bg_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_long_basic_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_aggr_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_udf_bg_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_ops_bg_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_pi_query_long_basic_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_aggr_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_udf_bg_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_ops_bg_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_long_basic_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_aggr_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_udf_bg_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_ops_bg_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2163,7 +2163,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(aerospike_namespace_client_udf_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+\nrate(aerospike_namespace_client_udf_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+\nrate(aerospike_namespace_client_udf_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_client_udf_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+\nrate(aerospike_namespace_client_udf_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+\nrate(aerospike_namespace_client_udf_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2172,14 +2172,14 @@
           "refId": "A"
         },
         {
-          "expr": "rate(aerospike_namespace_client_udf_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_client_udf_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{service}}/{{ns}}: Successful",
           "refId": "B"
         },
         {
-          "expr": "rate(aerospike_namespace_client_udf_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_client_udf_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2188,7 +2188,7 @@
           "refId": "C"
         },
         {
-          "expr": "rate(aerospike_namespace_client_udf_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_client_udf_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2308,7 +2308,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_master_objects{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2415,7 +2415,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_prole_objects{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_prole_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2522,7 +2522,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_non_replica_objects{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_non_replica_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2629,7 +2629,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_master_tombstones{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_master_tombstones{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2736,7 +2736,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_prole_tombstones{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_prole_tombstones{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2843,7 +2843,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_non_replica_tombstones{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_non_replica_tombstones{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2950,7 +2950,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_evicted_objects{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_evicted_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3058,7 +3058,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_expired_objects{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_expired_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3165,7 +3165,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_migrate_tx_partitions_remaining{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_migrate_tx_partitions_remaining{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -3174,7 +3174,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(aerospike_namespace_migrate_rx_partitions_remaining{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_migrate_rx_partitions_remaining{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -3282,7 +3282,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_namespace_xdr_tombstones{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_xdr_tombstones{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3391,7 +3391,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_namespace_xdr_bin_cemeteries{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_xdr_bin_cemeteries{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3513,7 +3513,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_memory_used_index_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_memory_used_index_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -3522,7 +3522,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(aerospike_namespace_index_flash_used_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_index_flash_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -3531,7 +3531,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(aerospike_namespace_index_pmem_used_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_index_pmem_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -3638,7 +3638,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_memory_used_sindex_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_memory_used_sindex_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -3747,7 +3747,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_namespace_memory_used_set_index_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
+          "expr": "sum(aerospike_namespace_memory_used_set_index_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (service, ns)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -3853,7 +3853,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_namespace_memory_free_pct{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_namespace_memory_free_pct{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -3862,7 +3862,7 @@
           "refId": "B"
         },
         {
-          "expr": "aerospike_namespace_high_water_memory_pct{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_namespace_high_water_memory_pct{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -3871,7 +3871,7 @@
           "refId": "A"
         },
         {
-          "expr": "aerospike_namespace_stop_writes_pct{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_namespace_stop_writes_pct{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -3985,7 +3985,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_namespace_memory_used_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_namespace_memory_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -4091,7 +4091,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_namespace_memory_size{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} - aerospike_namespace_memory_used_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_namespace_memory_size{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} - aerospike_namespace_memory_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -4196,7 +4196,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_namespace_device_free_pct{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_namespace_device_free_pct{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -4205,7 +4205,7 @@
           "refId": "B"
         },
         {
-          "expr": "aerospike_namespace_pmem_free_pct{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_namespace_pmem_free_pct{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -4311,7 +4311,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_namespace_device_used_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_namespace_device_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -4320,7 +4320,7 @@
           "refId": "B"
         },
         {
-          "expr": "aerospike_namespace_pmem_used_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_namespace_pmem_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -4426,7 +4426,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_namespace_device_total_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} - aerospike_namespace_device_used_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_namespace_device_total_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} - aerospike_namespace_device_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -4434,7 +4434,7 @@
           "refId": "A"
         },
         {
-          "expr": "aerospike_namespace_pmem_total_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} - aerospike_namespace_pmem_used_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
+          "expr": "aerospike_namespace_pmem_total_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} - aerospike_namespace_pmem_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -4541,7 +4541,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(aerospike_namespace_fail_generation{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_fail_generation{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -4551,7 +4551,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(aerospike_namespace_fail_key_busy{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_fail_key_busy{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -4561,7 +4561,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(aerospike_namespace_fail_record_too_big{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_fail_record_too_big{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -4571,7 +4571,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(aerospike_namespace_fail_xdr_forbidden{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_fail_xdr_forbidden{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -4581,7 +4581,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(aerospike_namespace_fail_client_lost_conflict{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_fail_client_lost_conflict{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -4592,7 +4592,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(aerospike_namespace_fail_xdr_lost_conflict{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+          "expr": "rate(aerospike_namespace_fail_xdr_lost_conflict{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -4711,7 +4711,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(aerospike_namespace_batch_sub_read_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_read_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -4720,7 +4720,7 @@
               "refId": "B"
             },
             {
-              "expr": "rate(aerospike_namespace_batch_sub_read_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_read_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -4729,7 +4729,7 @@
               "refId": "C"
             },
             {
-              "expr": "rate(aerospike_namespace_batch_sub_read_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_read_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -4738,7 +4738,7 @@
               "refId": "D"
             },
             {
-              "expr": "rate(aerospike_namespace_batch_sub_read_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_read_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "legendFormat": "{{service}}/{{ns}}: Timeout",
               "refId": "A"
             }
@@ -4840,7 +4840,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(aerospike_namespace_batch_sub_write_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_write_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -4849,7 +4849,7 @@
               "refId": "B"
             },
             {
-              "expr": "rate(aerospike_namespace_batch_sub_write_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_write_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -4858,7 +4858,7 @@
               "refId": "C"
             },
             {
-              "expr": "rate(aerospike_namespace_batch_sub_write_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_write_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -4867,7 +4867,7 @@
               "refId": "D"
             },
             {
-              "expr": "rate(aerospike_namespace_batch_sub_write_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_write_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "legendFormat": "{{service}}/{{ns}}: Timeout",
               "refId": "A"
             }
@@ -4969,7 +4969,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(aerospike_namespace_batch_sub_delete_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_delete_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -4978,7 +4978,7 @@
               "refId": "B"
             },
             {
-              "expr": "rate(aerospike_namespace_batch_sub_delete_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_delete_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -4987,7 +4987,7 @@
               "refId": "C"
             },
             {
-              "expr": "rate(aerospike_namespace_batch_sub_delete_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_delete_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -4996,7 +4996,7 @@
               "refId": "D"
             },
             {
-              "expr": "rate(aerospike_namespace_batch_sub_delete_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_delete_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "legendFormat": "{{service}}/{{ns}}: Timeout",
               "refId": "A"
             }
@@ -5098,7 +5098,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(aerospike_namespace_batch_sub_udf_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_udf_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -5107,7 +5107,7 @@
               "refId": "B"
             },
             {
-              "expr": "rate(aerospike_namespace_batch_sub_udf_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_udf_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -5116,7 +5116,7 @@
               "refId": "C"
             },
             {
-              "expr": "rate(aerospike_namespace_batch_sub_udf_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_udf_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -5125,7 +5125,7 @@
               "refId": "D"
             },
             {
-              "expr": "rate(aerospike_namespace_batch_sub_udf_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_udf_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "legendFormat": "{{service}}/{{ns}}: Timeout",
               "refId": "A"
             }
@@ -5227,7 +5227,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(aerospike_namespace_batch_sub_tsvc_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_tsvc_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -5236,7 +5236,7 @@
               "refId": "A"
             },
             {
-              "expr": "rate(aerospike_namespace_batch_sub_tsvc_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_batch_sub_tsvc_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -5358,7 +5358,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_long_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_aggr_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_udf_bg_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_ops_bg_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_long_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_aggr_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_udf_bg_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_ops_bg_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -5368,7 +5368,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_long_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_aggr_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_udf_bg_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_ops_bg_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_long_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_aggr_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_udf_bg_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_ops_bg_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5379,7 +5379,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_long_basic_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_aggr_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_udf_bg_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_ops_bg_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_long_basic_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_aggr_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_udf_bg_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_ops_bg_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5487,7 +5487,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_long_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_long_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -5497,7 +5497,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_long_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_long_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5508,7 +5508,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_long_basic_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_long_basic_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_pi_query_short_basic_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5616,7 +5616,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_aggr_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_aggr_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -5626,7 +5626,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_aggr_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_aggr_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5637,7 +5637,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_aggr_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_aggr_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5745,7 +5745,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_short_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_short_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -5755,7 +5755,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_short_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_short_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5766,7 +5766,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_short_basic_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_short_basic_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5874,7 +5874,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_long_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_long_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -5884,7 +5884,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_long_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_long_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5895,7 +5895,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_long_basic_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_long_basic_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6003,7 +6003,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_udf_bg_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_udf_bg_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -6013,7 +6013,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_udf_bg_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_udf_bg_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6024,7 +6024,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_udf_bg_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_udf_bg_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6132,7 +6132,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_ops_bg_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_ops_bg_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -6142,7 +6142,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_ops_bg_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_ops_bg_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6153,7 +6153,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_pi_query_ops_bg_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_pi_query_ops_bg_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6276,7 +6276,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_long_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_aggr_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_udf_bg_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_ops_bg_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_long_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_aggr_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_udf_bg_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_ops_bg_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -6286,7 +6286,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_long_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_aggr_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_udf_bg_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_ops_bg_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_long_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_aggr_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_udf_bg_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_ops_bg_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6297,7 +6297,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_long_basic_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_aggr_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_udf_bg_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_ops_bg_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_long_basic_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_aggr_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_udf_bg_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_ops_bg_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6405,7 +6405,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_long_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_long_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -6415,7 +6415,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_long_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_long_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6426,7 +6426,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_long_basic_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_long_basic_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_si_query_short_basic_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6534,7 +6534,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_short_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_short_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -6544,7 +6544,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_short_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_short_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6555,7 +6555,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_short_basic_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_short_basic_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6663,7 +6663,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_long_basic_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_long_basic_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -6673,7 +6673,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_long_basic_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_long_basic_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6684,7 +6684,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_long_basic_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_long_basic_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6792,7 +6792,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_aggr_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_aggr_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -6802,7 +6802,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_aggr_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_aggr_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6813,7 +6813,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_aggr_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_aggr_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6921,7 +6921,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_udf_bg_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_udf_bg_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -6931,7 +6931,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_udf_bg_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_udf_bg_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6942,7 +6942,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_udf_bg_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_udf_bg_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -7050,7 +7050,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_ops_bg_complete{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_ops_bg_complete{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -7060,7 +7060,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_ops_bg_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_ops_bg_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -7071,7 +7071,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(aerospike_namespace_si_query_ops_bg_abort{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
+              "expr": "rate(aerospike_namespace_si_query_ops_bg_abort{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -7194,7 +7194,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(rate(aerospike_namespace_sindex_gc_cleaned{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])) by (job,cluster_name,ns)",
+              "expr": "sum(rate(aerospike_namespace_sindex_gc_cleaned{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])) by (job,cluster_name,ns)",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -7260,7 +7260,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+        "definition": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -7270,7 +7270,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+          "query": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
           "refId": "Aerospike Prometheus-cluster-Variable-Query"
         },
         "refresh": 2,
@@ -7287,7 +7287,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_stats_uptime{job=\"aerospike\", cluster_name=~\"$cluster|$^\"},service)",
+        "definition": "label_values(aerospike_node_stats_uptime{job=\"$job_name\", cluster_name=~\"$cluster|$^\"},service)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -7297,7 +7297,7 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_stats_uptime{job=\"aerospike\", cluster_name=~\"$cluster|$^\"},service)",
+          "query": "label_values(aerospike_node_stats_uptime{job=\"$job_name\", cluster_name=~\"$cluster|$^\"},service)",
           "refId": "Aerospike Prometheus-node-Variable-Query"
         },
         "refresh": 2,
@@ -7314,7 +7314,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_namespace_objects{job=\"aerospike\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
+        "definition": "label_values(aerospike_namespace_objects{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -7324,7 +7324,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_namespace_objects{job=\"aerospike\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
+          "query": "label_values(aerospike_namespace_objects{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
           "refId": "Aerospike Prometheus-namespace-Variable-Query"
         },
         "refresh": 2,
@@ -7356,6 +7356,33 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "aerospike",
+          "value": "aerospike"
+        },
+        "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
+        "definition": "label_values(aerospike_node_stats_uptime,job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job_name",
+        "multi": false,
+        "name": "job_name",
+        "options": [],
+        "query": {
+          "query": "label_values(aerospike_node_stats_uptime,job)",
+          "refId": "Aerospike Prometheus-job-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },

--- a/config/grafana/dashboards/node.json
+++ b/config/grafana/dashboards/node.json
@@ -107,7 +107,7 @@
       "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "aerospike_node_up{job=\"aerospike\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\"}",
+          "expr": "aerospike_node_up{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\"}",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -228,7 +228,7 @@
       "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "aerospike_node_up{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"}",
+          "expr": "aerospike_node_up{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"}",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -299,7 +299,7 @@
       "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_objects{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"})",
+          "expr": "sum(aerospike_namespace_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -308,7 +308,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(aerospike_namespace_tombstones{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"})",
+          "expr": "sum(aerospike_namespace_tombstones{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -379,7 +379,7 @@
       "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_memory_size{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"})",
+          "expr": "sum(aerospike_namespace_memory_size{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -388,7 +388,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(aerospike_namespace_memory_used_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"})",
+          "expr": "sum(aerospike_namespace_memory_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -397,7 +397,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(aerospike_namespace_device_total_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"})",
+          "expr": "sum(aerospike_namespace_device_total_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -406,7 +406,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(aerospike_namespace_device_used_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"})",
+          "expr": "sum(aerospike_namespace_device_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -415,7 +415,7 @@
           "refId": "D"
         },
         {
-          "expr": "sum(aerospike_namespace_pmem_total_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"})",
+          "expr": "sum(aerospike_namespace_pmem_total_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -424,7 +424,7 @@
           "refId": "E"
         },
         {
-          "expr": "sum(aerospike_namespace_pmem_used_bytes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"})",
+          "expr": "sum(aerospike_namespace_pmem_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -493,7 +493,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(aerospike_latencies_udf_${latencytimeunit}_bucket{job=\"aerospike\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\", le=~\"[0-9]*\"}) by (le)",
+          "expr": "avg(aerospike_latencies_udf_${latencytimeunit}_bucket{job=\"$job_name\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\", le=~\"[0-9]*\"}) by (le)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -502,7 +502,7 @@
           "refId": "A"
         },
         {
-          "expr": "avg(aerospike_latencies_udf_${latencytimeunit}_count{job=\"aerospike\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
+          "expr": "avg(aerospike_latencies_udf_${latencytimeunit}_count{job=\"$job_name\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
           "legendFormat": "Ops/sec",
           "refId": "B"
         }
@@ -610,7 +610,7 @@
       "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "ALERTS{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"}",
+          "expr": "ALERTS{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -700,7 +700,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "aerospike_node_stats_failed_best_practices{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"}",
+          "expr": "aerospike_node_stats_failed_best_practices{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"}",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -770,7 +770,7 @@
       "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "aerospike_node_stats_client_connections{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"}",
+          "expr": "aerospike_node_stats_client_connections{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"}",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -779,7 +779,7 @@
           "refId": "A"
         },
         {
-          "expr": "aerospike_node_stats_heartbeat_connections{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"}",
+          "expr": "aerospike_node_stats_heartbeat_connections{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"}",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -788,7 +788,7 @@
           "refId": "B"
         },
         {
-          "expr": "aerospike_node_stats_fabric_connections{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"}",
+          "expr": "aerospike_node_stats_fabric_connections{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"}",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -866,7 +866,7 @@
       "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "min(aerospike_namespace_memory_free_pct{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"})",
+          "expr": "min(aerospike_namespace_memory_free_pct{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -875,7 +875,7 @@
           "refId": "A"
         },
         {
-          "expr": "min(aerospike_namespace_device_free_pct{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"})",
+          "expr": "min(aerospike_namespace_device_free_pct{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -884,7 +884,7 @@
           "refId": "B"
         },
         {
-          "expr": "min(aerospike_namespace_pmem_free_pct{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"})",
+          "expr": "min(aerospike_namespace_pmem_free_pct{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -955,7 +955,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(aerospike_latencies_read_${latencytimeunit}_bucket{job=\"aerospike\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\", le=~\"[0-9]*\"}) by (le)",
+          "expr": "avg(aerospike_latencies_read_${latencytimeunit}_bucket{job=\"$job_name\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\", le=~\"[0-9]*\"}) by (le)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -964,7 +964,7 @@
           "refId": "A"
         },
         {
-          "expr": "avg(aerospike_latencies_read_${latencytimeunit}_count{job=\"aerospike\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
+          "expr": "avg(aerospike_latencies_read_${latencytimeunit}_count{job=\"$job_name\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
           "legendFormat": "Ops/sec",
           "refId": "B"
         }
@@ -1067,7 +1067,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(aerospike_latencies_write_${latencytimeunit}_bucket{job=\"aerospike\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\", le=~\"[0-9]*\"}) by (le)",
+          "expr": "avg(aerospike_latencies_write_${latencytimeunit}_bucket{job=\"$job_name\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\", le=~\"[0-9]*\"}) by (le)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1076,7 +1076,7 @@
           "refId": "A"
         },
         {
-          "expr": "avg(aerospike_latencies_write_${latencytimeunit}_count{job=\"aerospike\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
+          "expr": "avg(aerospike_latencies_write_${latencytimeunit}_count{job=\"$job_name\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
           "legendFormat": "Ops/sec",
           "refId": "B"
         }
@@ -1179,7 +1179,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(aerospike_latencies_proxy_${latencytimeunit}_bucket{job=\"aerospike\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\", le=~\"[0-9]*\"}) by (le)",
+          "expr": "avg(aerospike_latencies_proxy_${latencytimeunit}_bucket{job=\"$job_name\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\", le=~\"[0-9]*\"}) by (le)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1188,7 +1188,7 @@
           "refId": "A"
         },
         {
-          "expr": "avg(aerospike_latencies_proxy_${latencytimeunit}_count{job=\"aerospike\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
+          "expr": "avg(aerospike_latencies_proxy_${latencytimeunit}_count{job=\"$job_name\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
           "legendFormat": "Ops/sec",
           "refId": "B"
         }
@@ -1291,7 +1291,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(aerospike_latencies_si_query_${latencytimeunit}_bucket{job=\"aerospike\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\", le=~\"[0-9]*\"}) by (le)",
+          "expr": "avg(aerospike_latencies_si_query_${latencytimeunit}_bucket{job=\"$job_name\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\", le=~\"[0-9]*\"}) by (le)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1300,7 +1300,7 @@
           "refId": "A"
         },
         {
-          "expr": "avg(aerospike_latencies_si_query_${latencytimeunit}_count{job=\"aerospike\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
+          "expr": "avg(aerospike_latencies_si_query_${latencytimeunit}_count{job=\"$job_name\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
           "legendFormat": "Ops/sec",
           "refId": "B"
         }
@@ -1403,7 +1403,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(aerospike_latencies_pi_query_${latencytimeunit}_bucket{job=\"aerospike\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\", le=~\"[0-9]*\"}) by (le)",
+          "expr": "avg(aerospike_latencies_pi_query_${latencytimeunit}_bucket{job=\"$job_name\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\", le=~\"[0-9]*\"}) by (le)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1412,7 +1412,7 @@
           "refId": "A"
         },
         {
-          "expr": "avg(aerospike_latencies_pi_query_${latencytimeunit}_count{job=\"aerospike\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
+          "expr": "avg(aerospike_latencies_pi_query_${latencytimeunit}_count{job=\"$job_name\",cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
           "legendFormat": "Ops/sec",
           "refId": "B"
         }
@@ -1517,7 +1517,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(aerospike_node_stats_client_connections_opened{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}[1m])",
+          "expr": "rate(aerospike_node_stats_client_connections_opened{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}[1m])",
           "hide": false,
           "interval": "",
           "legendFormat": "Client Connections Opened",
@@ -1525,7 +1525,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(aerospike_node_stats_client_connections_closed{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}[1m])",
+          "expr": "rate(aerospike_node_stats_client_connections_closed{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}[1m])",
           "hide": false,
           "interval": "",
           "legendFormat": "Client Connections Closed",
@@ -1533,7 +1533,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(aerospike_node_stats_heartbeat_connections_opened{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}[1m])",
+          "expr": "rate(aerospike_node_stats_heartbeat_connections_opened{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}[1m])",
           "hide": false,
           "interval": "",
           "legendFormat": "Heartbeat Connections Opened",
@@ -1541,7 +1541,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(aerospike_node_stats_heartbeat_connections_closed{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}[1m])",
+          "expr": "rate(aerospike_node_stats_heartbeat_connections_closed{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}[1m])",
           "hide": false,
           "interval": "",
           "legendFormat": "Heartbeat Connections Closed",
@@ -1549,7 +1549,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(aerospike_node_stats_fabric_connections_opened{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}[1m])",
+          "expr": "rate(aerospike_node_stats_fabric_connections_opened{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}[1m])",
           "hide": false,
           "interval": "",
           "legendFormat": "Fabric Connections Opened",
@@ -1557,7 +1557,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(aerospike_node_stats_fabric_connections_closed{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}[1m])",
+          "expr": "rate(aerospike_node_stats_fabric_connections_closed{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}[1m])",
           "hide": false,
           "interval": "",
           "legendFormat": "Fabric Connections Closed",
@@ -1661,7 +1661,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(aerospike_namespace_migrate_rx_partitions_remaining{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"})",
+          "expr": "sum(aerospike_namespace_migrate_rx_partitions_remaining{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"})",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -1669,7 +1669,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(aerospike_namespace_migrate_tx_partitions_remaining{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\"})",
+          "expr": "sum(aerospike_namespace_migrate_tx_partitions_remaining{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\"})",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -1775,7 +1775,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_namespace_master_objects{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
+          "expr": "aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1784,14 +1784,14 @@
           "refId": "A"
         },
         {
-          "expr": "aerospike_namespace_prole_objects{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
+          "expr": "aerospike_namespace_prole_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ns}}/Prole",
           "refId": "B"
         },
         {
-          "expr": "aerospike_namespace_tombstones{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
+          "expr": "aerospike_namespace_tombstones{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ns}}/Tombstones",
@@ -1897,7 +1897,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "aerospike_node_stats_threads_detached{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
+          "expr": "aerospike_node_stats_threads_detached{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1907,7 +1907,7 @@
         },
         {
           "exemplar": true,
-          "expr": "aerospike_node_stats_threads_joinable{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
+          "expr": "aerospike_node_stats_threads_joinable{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1917,7 +1917,7 @@
         },
         {
           "exemplar": true,
-          "expr": "aerospike_node_stats_threads_pool_active{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
+          "expr": "aerospike_node_stats_threads_pool_active{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1927,7 +1927,7 @@
         },
         {
           "exemplar": true,
-          "expr": "aerospike_node_stats_threads_pool_total{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
+          "expr": "aerospike_node_stats_threads_pool_total{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2035,7 +2035,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_node_stats_client_connections{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
+          "expr": "aerospike_node_stats_client_connections{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2044,14 +2044,14 @@
           "refId": "A"
         },
         {
-          "expr": "aerospike_node_stats_fabric_connections{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
+          "expr": "aerospike_node_stats_fabric_connections{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Fabric Connections",
           "refId": "B"
         },
         {
-          "expr": "aerospike_node_stats_heartbeat_connections{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
+          "expr": "aerospike_node_stats_heartbeat_connections{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Heartbeat Connections",
@@ -2156,7 +2156,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_read_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_read_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_read_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2165,14 +2165,14 @@
           "refId": "B"
         },
         {
-          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_read_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_read_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{service}}: Successful",
           "refId": "A"
         },
         {
-          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_read_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_read_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2181,7 +2181,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_read_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_read_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2190,7 +2190,7 @@
           "refId": "D"
         },
         {
-          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_read_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_read_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_read_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2296,21 +2296,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_write_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_write_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_write_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_write_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_write_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m])+rate(aerospike_namespace_client_write_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{service}}: Total",
           "refId": "B"
         },
         {
-          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_write_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_write_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{service}}: Successful",
           "refId": "A"
         },
         {
-          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_write_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_timeout{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_write_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_timeout{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2318,7 +2318,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_write_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_error{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
+          "expr": "sum by (job, cluster_name, service) (rate(aerospike_namespace_client_write_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]) + rate(aerospike_namespace_batch_sub_write_error{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{service}}: Error",
@@ -2378,7 +2378,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_up{job=\"aerospike\"},cluster_name)",
+        "definition": "label_values(aerospike_node_up{job=\"$job_name\"},cluster_name)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2388,7 +2388,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_up{job=\"aerospike\"},cluster_name)",
+          "query": "label_values(aerospike_node_up{job=\"$job_name\"},cluster_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -2405,7 +2405,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_up{job=\"aerospike\", cluster_name=~\"$cluster|$^\"},service)",
+        "definition": "label_values(aerospike_node_up{job=\"$job_name\", cluster_name=~\"$cluster|$^\"},service)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2415,7 +2415,7 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_up{job=\"aerospike\", cluster_name=~\"$cluster|$^\"},service)",
+          "query": "label_values(aerospike_node_up{job=\"$job_name\", cluster_name=~\"$cluster|$^\"},service)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -2432,7 +2432,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_namespace_objects{job=\"aerospike\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
+        "definition": "label_values(aerospike_namespace_objects{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2442,7 +2442,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_namespace_objects{job=\"aerospike\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
+          "query": "label_values(aerospike_namespace_objects{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },ns)",
           "refId": "Aerospike Prometheus-namespace-Variable-Query"
         },
         "refresh": 2,
@@ -2501,6 +2501,33 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "aerospike",
+          "value": "aerospike"
+        },
+        "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
+        "definition": "label_values(aerospike_node_stats_uptime,job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job_name",
+        "multi": false,
+        "name": "job_name",
+        "options": [],
+        "query": {
+          "query": "label_values(aerospike_node_stats_uptime,job)",
+          "refId": "Aerospike Prometheus-job-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },

--- a/config/grafana/dashboards/sindex.json
+++ b/config/grafana/dashboards/sindex.json
@@ -149,7 +149,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg(aerospike_sindex_memory_used{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", sindex=~\"$sindex\"})",
+          "expr": "avg(aerospike_sindex_memory_used{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", sindex=~\"$sindex\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -211,7 +211,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "min(aerospike_sindex_load_pct{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", sindex=~\"$sindex\"})",
+          "expr": "min(aerospike_sindex_load_pct{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", sindex=~\"$sindex\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -275,7 +275,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "max(aerospike_sindex_load_time{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", sindex=~\"$sindex\"})",
+          "expr": "max(aerospike_sindex_load_time{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", sindex=~\"$sindex\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -334,7 +334,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_sindex_entries{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", sindex=~\"$sindex\"}) / max(aerospike_namespace_effective_replication_factor{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\"})",
+          "expr": "sum(aerospike_sindex_entries{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", sindex=~\"$sindex\"}) / max(aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -393,7 +393,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_sindex_entries_per_bval{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", sindex=~\"$sindex\"})",
+          "expr": "sum(aerospike_sindex_entries_per_bval{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", sindex=~\"$sindex\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -452,7 +452,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_sindex_entries_per_rec{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", sindex=~\"$sindex\"})",
+          "expr": "sum(aerospike_sindex_entries_per_rec{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", sindex=~\"$sindex\"})",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -514,7 +514,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(increase(aerospike_sindex_stat_gc_recs{job=\"aerospike\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", sindex=~\"$sindex\"}[5m]))",
+          "expr": "sum(increase(aerospike_sindex_stat_gc_recs{job=\"$job_name\", cluster_name=~\"$cluster\", ns=~\"$namespace|$^\", sindex=~\"$sindex\"}[5m]))",
           "hide": false,
           "instant": false,
           "interval": "",
@@ -595,7 +595,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+        "definition": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -605,7 +605,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+          "query": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -622,7 +622,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_namespace_objects{job=\"aerospike\", cluster_name=~\"$cluster|$^\" },ns)",
+        "definition": "label_values(aerospike_namespace_objects{job=\"$job_name\", cluster_name=~\"$cluster|$^\" },ns)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -632,7 +632,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_namespace_objects{job=\"aerospike\", cluster_name=~\"$cluster|$^\" },ns)",
+          "query": "label_values(aerospike_namespace_objects{job=\"$job_name\", cluster_name=~\"$cluster|$^\" },ns)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -649,7 +649,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_sindex_entries{job=\"aerospike\", cluster_name=~\"$cluster|$^\", ns=~\"$namespace|$^\" },sindex)",
+        "definition": "label_values(aerospike_sindex_entries{job=\"$job_name\", cluster_name=~\"$cluster|$^\", ns=~\"$namespace|$^\" },sindex)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -659,7 +659,7 @@
         "name": "sindex",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_sindex_entries{job=\"aerospike\", cluster_name=~\"$cluster|$^\", ns=~\"$namespace|$^\" },sindex)",
+          "query": "label_values(aerospike_sindex_entries{job=\"$job_name\", cluster_name=~\"$cluster|$^\", ns=~\"$namespace|$^\" },sindex)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -668,6 +668,33 @@
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "aerospike",
+          "value": "aerospike"
+        },
+        "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
+        "definition": "label_values(aerospike_node_stats_uptime,job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job_name",
+        "multi": false,
+        "name": "job_name",
+        "options": [],
+        "query": {
+          "query": "label_values(aerospike_node_stats_uptime,job)",
+          "refId": "Aerospike Prometheus-job-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",
         "useTags": false

--- a/config/grafana/dashboards/users.json
+++ b/config/grafana/dashboards/users.json
@@ -85,7 +85,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_users_conns_in_use{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
+          "expr": "sum(aerospike_users_conns_in_use{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
           "instant": false,
           "interval": "",
           "legendFormat": "{{user}}",
@@ -142,7 +142,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_users_read_single_record_tps{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
+          "expr": "sum(aerospike_users_read_single_record_tps{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
           "instant": false,
           "interval": "",
           "legendFormat": "{{user}}",
@@ -199,7 +199,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_users_write_single_record_tps{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
+          "expr": "sum(aerospike_users_write_single_record_tps{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
           "instant": false,
           "interval": "",
           "legendFormat": "{{user}}",
@@ -256,7 +256,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_users_read_scan_query_rps{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
+          "expr": "sum(aerospike_users_read_scan_query_rps{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
           "instant": false,
           "interval": "",
           "legendFormat": "{{user}}",
@@ -313,7 +313,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_users_write_scan_query_rps{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
+          "expr": "sum(aerospike_users_write_scan_query_rps{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
           "instant": false,
           "interval": "",
           "legendFormat": "{{user}}",
@@ -370,7 +370,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_users_limitless_read_scan_query{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
+          "expr": "sum(aerospike_users_limitless_read_scan_query{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
           "instant": false,
           "interval": "",
           "legendFormat": "{{user}}",
@@ -427,7 +427,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_users_limitless_write_scan_query{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
+          "expr": "sum(aerospike_users_limitless_write_scan_query{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
           "instant": false,
           "interval": "",
           "legendFormat": "{{user}}",
@@ -493,7 +493,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_users_read_quota{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
+          "expr": "sum(aerospike_users_read_quota{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
           "instant": false,
           "interval": "",
           "legendFormat": "{{user}}",
@@ -559,7 +559,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(aerospike_users_write_quota{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
+          "expr": "sum(aerospike_users_write_quota{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", user=~\"$user\"}) by (user)",
           "instant": false,
           "interval": "",
           "legendFormat": "{{user}}",
@@ -580,7 +580,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_users_conns_in_use{job=\"aerospike\"},user)",
+        "definition": "label_values(aerospike_users_conns_in_use{job=\"$job_name\"},user)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -590,7 +590,7 @@
         "name": "user",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_users_conns_in_use{job=\"aerospike\"},user)",
+          "query": "label_values(aerospike_users_conns_in_use{job=\"$job_name\"},user)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -607,7 +607,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+        "definition": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -617,7 +617,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+          "query": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -634,7 +634,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_stats_uptime{job=\"aerospike\", cluster_name=~\"$cluster|$^\"},service)",
+        "definition": "label_values(aerospike_node_stats_uptime{job=\"$job_name\", cluster_name=~\"$cluster|$^\"},service)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -644,7 +644,7 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_stats_uptime{job=\"aerospike\", cluster_name=~\"$cluster|$^\"},service)",
+          "query": "label_values(aerospike_node_stats_uptime{job=\"$job_name\", cluster_name=~\"$cluster|$^\"},service)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -677,6 +677,33 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "aerospike",
+          "value": "aerospike"
+        },
+        "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
+        "definition": "label_values(aerospike_node_stats_uptime,job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job_name",
+        "multi": false,
+        "name": "job_name",
+        "options": [],
+        "query": {
+          "query": "label_values(aerospike_node_stats_uptime,job)",
+          "refId": "Aerospike Prometheus-job-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },

--- a/config/grafana/dashboards/xdr.json
+++ b/config/grafana/dashboards/xdr.json
@@ -169,49 +169,49 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "sum(aerospike_xdr_throughput{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"})",
+          "expr": "sum(aerospike_xdr_throughput{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"})",
           "interval": "",
           "legendFormat": "Total Throughput",
           "refId": "A"
         },
         {
-          "expr": "avg(aerospike_xdr_lag{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"})",
+          "expr": "avg(aerospike_xdr_lag{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"})",
           "interval": "",
           "legendFormat": "Avg Lag",
           "refId": "B"
         },
         {
-          "expr": "avg(aerospike_xdr_latency_ms{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"})",
+          "expr": "avg(aerospike_xdr_latency_ms{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"})",
           "interval": "",
           "legendFormat": "Avg Ship Latency",
           "refId": "C"
         },
         {
-          "expr": "avg(aerospike_xdr_lap_us{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"})",
+          "expr": "avg(aerospike_xdr_lap_us{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"})",
           "interval": "",
           "legendFormat": "Avg Lap us",
           "refId": "D"
         },
         {
-          "expr": "sum(aerospike_xdr_recoveries_pending{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"})",
+          "expr": "sum(aerospike_xdr_recoveries_pending{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"})",
           "interval": "",
           "legendFormat": "Total Recoveries Pending",
           "refId": "E"
         },
         {
-          "expr": "sum(aerospike_xdr_in_progress{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"})",
+          "expr": "sum(aerospike_xdr_in_progress{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"})",
           "interval": "",
           "legendFormat": "Total In Progress",
           "refId": "F"
         },
         {
-          "expr": "sum(aerospike_xdr_in_queue{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"})",
+          "expr": "sum(aerospike_xdr_in_queue{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"})",
           "interval": "",
           "legendFormat": "Total In Queue",
           "refId": "G"
         },
         {
-          "expr": "sum(rate(aerospike_xdr_bytes_shipped{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m]))",
+          "expr": "sum(rate(aerospike_xdr_bytes_shipped{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m]))",
           "interval": "",
           "legendFormat": "Total bytes shipped",
           "refId": "H"
@@ -278,7 +278,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "avg(aerospike_xdr_nodes{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node\", dc=~\"$dc\"}) by (dc)",
+          "expr": "avg(aerospike_xdr_nodes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node\", dc=~\"$dc\"}) by (dc)",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -358,7 +358,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_xdr_throughput{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
+          "expr": "aerospike_xdr_throughput{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
           "legendFormat": "Throughput {{service}} {{dc}}",
           "refId": "A"
         }
@@ -456,7 +456,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(aerospike_xdr_success{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
+          "expr": "rate(aerospike_xdr_success{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
           "legendFormat": "Success {{service}} {{dc}}",
           "refId": "A"
         }
@@ -554,7 +554,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(aerospike_xdr_abandoned{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
+          "expr": "rate(aerospike_xdr_abandoned{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
           "legendFormat": "Abandoned {{service}} {{dc}}",
           "refId": "A"
         }
@@ -652,7 +652,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(aerospike_xdr_not_found{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
+          "expr": "rate(aerospike_xdr_not_found{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
           "legendFormat": "Not found {{service}} {{dc}}",
           "refId": "A"
         }
@@ -750,7 +750,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(aerospike_xdr_filtered_out{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
+          "expr": "rate(aerospike_xdr_filtered_out{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
           "legendFormat": "Filtered out {{service}} {{dc}}",
           "refId": "A"
         }
@@ -848,7 +848,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(aerospike_xdr_retry_conn_reset{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
+          "expr": "rate(aerospike_xdr_retry_conn_reset{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
           "legendFormat": "Retry Conn Reset {{service}} {{dc}}",
           "refId": "A"
         }
@@ -946,7 +946,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(aerospike_xdr_retry_dest{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
+          "expr": "rate(aerospike_xdr_retry_dest{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
           "legendFormat": "Retry Destination {{service}} {{dc}}",
           "refId": "A"
         }
@@ -1044,7 +1044,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(aerospike_xdr_hot_keys{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
+          "expr": "rate(aerospike_xdr_hot_keys{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
           "legendFormat": "Hot keys {{service}} {{dc}}",
           "refId": "A"
         }
@@ -1140,7 +1140,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_xdr_in_progress{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
+          "expr": "aerospike_xdr_in_progress{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
           "legendFormat": "In Progress {{service}} {{dc}}",
           "refId": "A"
         }
@@ -1236,7 +1236,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_xdr_in_queue{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
+          "expr": "aerospike_xdr_in_queue{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
           "legendFormat": "In queue {{service}} {{dc}}",
           "refId": "A"
         }
@@ -1333,7 +1333,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_xdr_lag{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
+          "expr": "aerospike_xdr_lag{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
           "legendFormat": "Lag {{service}} {{dc}}",
           "refId": "A"
         }
@@ -1429,7 +1429,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_xdr_lap_us{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
+          "expr": "aerospike_xdr_lap_us{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
           "legendFormat": "Lap μs {{service}} {{dc}}",
           "refId": "A"
         }
@@ -1527,7 +1527,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(aerospike_xdr_recoveries{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
+          "expr": "rate(aerospike_xdr_recoveries{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}[1m])",
           "legendFormat": "Recoveries {{service}} {{dc}}",
           "refId": "A"
         }
@@ -1623,7 +1623,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_xdr_recoveries_pending{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
+          "expr": "aerospike_xdr_recoveries_pending{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
           "legendFormat": "Recoveries pending {{service}} {{dc}}",
           "refId": "A"
         }
@@ -1719,7 +1719,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_xdr_latency_ms{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
+          "expr": "aerospike_xdr_latency_ms{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
           "legendFormat": "Latency ms {{service}} {{dc}}",
           "refId": "A"
         }
@@ -1815,7 +1815,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_xdr_compression_ratio{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
+          "expr": "aerospike_xdr_compression_ratio{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
           "legendFormat": "Avg compression ratio {{service}} {{dc}}",
           "refId": "A"
         }
@@ -1911,7 +1911,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aerospike_xdr_uncompressed_pct{job=\"aerospike\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
+          "expr": "aerospike_xdr_uncompressed_pct{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", dc=~\"$dc|$^\"}",
           "legendFormat": "Uncompressed pct {{service}} {{dc}}",
           "refId": "A"
         }
@@ -1968,7 +1968,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+        "definition": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1978,7 +1978,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_stats_uptime{job=\"aerospike\"},cluster_name)",
+          "query": "label_values(aerospike_node_stats_uptime{job=\"$job_name\"},cluster_name)",
           "refId": "Aerospike Prometheus-cluster-Variable-Query"
         },
         "refresh": 2,
@@ -1995,7 +1995,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_node_stats_uptime{job=\"aerospike\", cluster_name=~\"$cluster|$^\"},service)",
+        "definition": "label_values(aerospike_node_stats_uptime{job=\"$job_name\", cluster_name=~\"$cluster|$^\"},service)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2005,7 +2005,7 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_node_stats_uptime{job=\"aerospike\", cluster_name=~\"$cluster|$^\"},service)",
+          "query": "label_values(aerospike_node_stats_uptime{job=\"$job_name\", cluster_name=~\"$cluster|$^\"},service)",
           "refId": "Aerospike Prometheus-node-Variable-Query"
         },
         "refresh": 2,
@@ -2022,7 +2022,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
-        "definition": "label_values(aerospike_xdr_lap_us{job=\"aerospike\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },dc)",
+        "definition": "label_values(aerospike_xdr_lap_us{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },dc)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2032,7 +2032,7 @@
         "name": "dc",
         "options": [],
         "query": {
-          "query": "label_values(aerospike_xdr_lap_us{job=\"aerospike\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },dc)",
+          "query": "label_values(aerospike_xdr_lap_us{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\" },dc)",
           "refId": "Aerospike Prometheus-dc-Variable-Query"
         },
         "refresh": 2,
@@ -2065,6 +2065,33 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "aerospike",
+          "value": "aerospike"
+        },
+        "datasource": "${DS_AEROSPIKE_PROMETHEUS}",
+        "definition": "label_values(aerospike_node_stats_uptime,job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job_name",
+        "multi": false,
+        "name": "job_name",
+        "options": [],
+        "query": {
+          "query": "label_values(aerospike_node_stats_uptime,job)",
+          "refId": "Aerospike Prometheus-job-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },


### PR DESCRIPTION
**Problem:** 
I have already installed Prometheus and Grafana. I want to use these stack for monitoring aerospike.
I installed Aerospike with helm chart to my Kubernetes cluster. When I install aerospike with diffrent name I saw none of the metrics were working. The `job` is used everwhere statically.

`sum(aerospike_namespace_stop_writes{job="aerospike", cluster_name=~"$cluster", service=~"$node|$^", ns=~"$namespace|$^"})`

**Solution:**
Then I added new variable name `job_name` and I used `job` dynamically.
![resim](https://user-images.githubusercontent.com/16039143/201486250-e8664280-3cce-4762-9453-cc4f876c0155.png)
