### PR TITLE
Om 59 - added a dashboard linter

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -2,9 +2,9 @@ name: aerospike dashboard linter
 
 on:
   push:
-    branches: [ "OM-59" ]
+    branches: [ "dev" ]
   pull_request:
-    branches: [ "OM-59" ]
+    branches: [ "dev" ]
 
 jobs:
 

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,31 @@
+name: aerospike dashboard linter
+
+on:
+  push:
+    branches: [ "OM-59" ]
+  pull_request:
+    branches: [ "OM-59" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10' 
+
+    - name: Install 
+      run: pip install jsonschema-cli
+
+    - name: validate all json files against dashboard_schema.json
+      run: |
+         json_files=$(find ./config/grafana/dashboards -type f -name "*.json" -printf "$(realpath -s %p) ")
+         
+         for file in $json_files; do
+           echo "validating file === $file"
+           jsonschema-cli validate build/dashboard_schema.json $file 
+         done

--- a/build/dashboard_schema.json
+++ b/build/dashboard_schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aerospike.com/dashboard.schema.json",
+  "title": "Observability Dashboards",
+  "description": "Aerospike grafana dashboard json, defines rules for mandatory nodes and unnecessary nodes",
+  "comments":"Schema is validated against dashboards for non-existance of __inputs, __elements and existance of __requires mandatory field ",
+  "properties": {
+    "__inputs":{
+      "description": "defines the input section of datasource, constant, expressions etc.,",
+      "comments": "__inputs is a node in Grafana Dashboard this should not exist to avoid prompting for Datasource during dashboard import and working ",
+      "type": "array",
+      "not": {}
+      },
+
+    "__elements":{
+        "description":"defines the various elements used within panels in the dashboard",
+        "comments": "__elements is a node in Grafana Dashboard, this should not exist to avoid issues during dashboard import and working ",
+        "type": "array",
+        "not": {}
+        }
+  },
+
+  "required": [ "__requires" ]
+}

--- a/config/grafana/dashboards/jobs.json
+++ b/config/grafana/dashboards/jobs.json
@@ -1,5 +1,5 @@
 {
-  "__requires": [
+  "__require": [
     {
       "type": "panel",
       "id": "gauge",

--- a/config/grafana/dashboards/jobs.json
+++ b/config/grafana/dashboards/jobs.json
@@ -1,5 +1,5 @@
 {
-  "__require": [
+  "__requires": [
     {
       "type": "panel",
       "id": "gauge",


### PR DESCRIPTION
created a simple schema for dashboard validation 
created a GitHub Action which uses python based "jsonschema-cli" tool to validate dashboard against schema during push/pull-request, this command executes against each dashboard json file