### PR TITLE
OM60 - POC to sending server metrics partner solution

### DIFF
--- a/examples/otel/cloudwatch-docker-compose.yml
+++ b/examples/otel/cloudwatch-docker-compose.yml
@@ -1,0 +1,45 @@
+version: "3.7"
+services:
+
+  exporter:
+    image: aerospike/aerospike-prometheus-exporter:latest
+    networks:
+      - aerospike_otel_nw
+    container_name: as_prom_exporter
+    environment:
+    - AS_HOST=as_server
+    - AS_PORT=3000
+    - "METRIC_LABELS=type='development',source='aerospike'"
+    extra_hosts:
+    - "host.docker.internal:host-gateway"
+
+  aerospike_ce:
+    image: aerospike/aerospike-server:latest 
+    networks:
+      - aerospike_otel_nw
+    container_name: as_server
+
+  # Collector
+  otel-collector:
+    networks:
+      - aerospike_otel_nw
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: as_otel_contrib
+    privileged: true
+    restart: always
+    environment:
+    - AWS_REGION=ap-south-1
+    - AWS_ACCESS_KEY_ID=<MENTION-YOUR-AWS-CLOUD-WATCH-KEY>
+    - AWS_SECRET_ACCESS_KEY=<MENTION-YOUR-AWS-CW-SECRET-ACCESS-KEY>
+    volumes:
+    - source: ./cloudwatch-otel-collector-config.yml 
+      target: /etc/otel-collector-config.yml 
+      type: bind
+    command: ["--config=/etc/otel-collector-config.yml"]
+
+volumes:
+  otel_prometheus_data: {}
+  otel_data: {}
+networks:
+  aerospike_otel_nw:
+    driver: bridge

--- a/examples/otel/cloudwatch-otel-collector-config.yml
+++ b/examples/otel/cloudwatch-otel-collector-config.yml
@@ -1,0 +1,50 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "as_otel_contrib:4317"
+
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: 'otel_as_demo_server'
+        scrape_interval: 10s
+        static_configs:
+          - targets: ['as_prom_exporter:9145']
+
+exporters:
+  prometheus:
+    endpoint: "as_otel_contrib:30145"
+
+  awsemf:
+    namespace: "otel_dc_as_test"
+    region: "ap-south-1"
+    output_destination: cloudwatch
+    dimension_rollup_option: ZeroAndSingleDimensionRollup
+    detailed_metrics: true
+    retain_initial_value_of_delta_metric: true
+    metric_declarations:
+      - dimensions: [[ns,cluster_name,service,file, file_index,set,module,job_type,trid,sindex_name,sindex,user,dc], []]
+        metric_name_selectors:
+         - "^aerospike"        
+
+  logging:
+
+processors:
+  batch:
+
+extensions:
+  health_check:
+  pprof:
+    endpoint: :1888
+  zpages:
+    endpoint: :55679
+
+service:
+  extensions: [pprof, zpages, health_check]
+  pipelines:
+    metrics:
+      receivers: [prometheus ]
+      processors: [batch]
+      exporters: [logging , prometheus, awsemf]
+

--- a/examples/otel/datadog-docker-compose.yml
+++ b/examples/otel/datadog-docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.7"
+services:
+
+  exporter:
+    image: aerospike/aerospike-prometheus-exporter:latest
+    networks:
+      - aerospike_otel_nw
+    container_name: as_prom_exporter
+    environment:
+    - AS_HOST=as_server
+    - AS_PORT=3000
+    - "METRIC_LABELS=type='development',source='aerospike'"
+    extra_hosts:
+    - "host.docker.internal:host-gateway"
+
+  aerospike_ce:
+    image: aerospike/aerospike-server:latest 
+    networks:
+      - aerospike_otel_nw
+    container_name: as_server
+
+  # Collector
+  otel-collector:
+    networks:
+      - aerospike_otel_nw
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: as_otel_contrib
+    privileged: true
+    restart: always
+    volumes:
+    - source: ./datadog-otel-collector-config.yml 
+      target: /etc/otel-collector-config.yml 
+      type: bind
+    command: ["--config=/etc/otel-collector-config.yml"]
+
+volumes:
+  otel_prometheus_data: {}
+  otel_data: {}
+networks:
+  aerospike_otel_nw:
+    driver: bridge

--- a/examples/otel/datadog-otel-collector-config.yml
+++ b/examples/otel/datadog-otel-collector-config.yml
@@ -1,0 +1,50 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "as_otel_contrib:4317"
+
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: 'otel_as_demos'
+        scrape_interval: 10s
+        static_configs:
+          - targets: ['as_prom_exporter:9145']
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:30145"
+
+  datadog:
+    api: 
+      site: datadoghq.com
+      key: <DATADOG-APP-KEY>
+      
+  logging:
+
+processors:
+  batch:
+        send_batch_max_size: 100
+        send_batch_size: 10
+        timeout: 10s
+
+extensions:
+  health_check:
+  pprof:
+    endpoint: :1888
+  zpages:
+    endpoint: :55679
+
+service:
+  extensions: [pprof, zpages, health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, datadog ]
+    metrics:
+      receivers: [prometheus ]
+      processors: [batch]
+      exporters: [logging , prometheus, datadog]
+

--- a/examples/otel/multi-docker-compose.yml
+++ b/examples/otel/multi-docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.7"
+services:
+
+  exporter:
+    image: aerospike/aerospike-prometheus-exporter:latest
+    networks:
+      - aerospike_otel_nw
+    container_name: as_prom_exporter
+    environment:
+    - AS_HOST=as_server
+    - AS_PORT=3000
+    - "METRIC_LABELS=type='development',source='aerospike'"
+    extra_hosts:
+    - "host.docker.internal:host-gateway"
+
+  aerospike_ce:
+    image: aerospike/aerospike-server:latest 
+    networks:
+      - aerospike_otel_nw
+    container_name: as_server
+
+  # Collector
+  otel-collector:
+    networks:
+      - aerospike_otel_nw
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: as_otel_contrib
+    privileged: true
+    restart: always
+    volumes:
+    - source: ./multi-otel-collector-config.yml 
+      target: /etc/otel-collector-config.yml 
+      type: bind
+    command: ["--config=/etc/otel-collector-config.yml"]
+
+volumes:
+  otel_prometheus_data: {}
+  otel_data: {}
+networks:
+  aerospike_otel_nw:
+    driver: bridge

--- a/examples/otel/multi-otel-collector-config.yml
+++ b/examples/otel/multi-otel-collector-config.yml
@@ -1,0 +1,52 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "as_otel_contrib:4317"
+
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: 'otel_as_demos'
+        scrape_interval: 10s
+        static_configs:
+          - targets: ['as_prom_exporter:9145']
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:30145"
+
+  datadog:
+    api: 
+      site: datadoghq.com
+      key: <DATADOG-APP-KEY>
+
+  otlp:
+    endpoint: https://otlp.nr-data.net:4317 
+    headers:
+      api-key: <NEWRELIC-API-KEY>
+
+  logging:
+
+processors:
+  batch:
+
+extensions:
+  health_check:
+  pprof:
+    endpoint: :1888
+  zpages:
+    endpoint: :55679
+
+service:
+  extensions: [pprof, zpages, health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp, logging ]
+    metrics:
+      receivers: [prometheus ]
+      processors: [batch]
+      exporters: [otlp,logging , prometheus, datadog]
+

--- a/examples/otel/newrelic-docker-compose.yml
+++ b/examples/otel/newrelic-docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.7"
+services:
+
+  exporter:
+    image: aerospike/aerospike-prometheus-exporter:latest
+    networks:
+      - aerospike_otel_nw
+    container_name: as_prom_exporter
+    environment:
+    - AS_HOST=as_server
+    - AS_PORT=3000
+    - "METRIC_LABELS=type='development',source='aerospike'"
+    extra_hosts:
+    - "host.docker.internal:host-gateway"
+
+  aerospike_ce:
+    image: aerospike/aerospike-server:latest 
+    networks:
+      - aerospike_otel_nw
+    container_name: as_server
+
+  # Collector
+  otel-collector:
+    networks:
+      - aerospike_otel_nw
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: as_otel_contrib
+    privileged: true
+    restart: always
+    volumes:
+    - source: ./newrelic-otel-collector-config.yml 
+      target: /etc/otel-collector-config.yml 
+      type: bind
+    command: ["--config=/etc/otel-collector-config.yml"]
+
+volumes:
+  otel_prometheus_data: {}
+  otel_data: {}
+networks:
+  aerospike_otel_nw:
+    driver: bridge

--- a/examples/otel/newrelic-otel-collector-config.yml
+++ b/examples/otel/newrelic-otel-collector-config.yml
@@ -1,0 +1,47 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "as_otel_contrib:4317"
+
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: 'otel_as_demos'
+        scrape_interval: 10s
+        static_configs:
+          - targets: ['as_prom_exporter:9145']
+
+exporters:
+  prometheus:
+    endpoint: "as_otel_contrib:30145"
+
+  otlp:
+    endpoint: https://otlp.nr-data.net:4317 
+    headers:
+      api-key: <NEWRELIC-API-KEY>
+
+  logging:
+
+processors:
+  batch:
+
+extensions:
+  health_check:
+  pprof:
+    endpoint: :1888
+  zpages:
+    endpoint: :55679
+
+service:
+  extensions: [pprof, zpages, health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp, logging ]
+    metrics:
+      receivers: [prometheus ]
+      processors: [batch]
+      exporters: [otlp,logging , prometheus]
+


### PR DESCRIPTION
created support with OTel Collector to send server metrics to
1. NewRelic, 2. DataDog, 3. CloudWatch, and 4. Multiple partner solutions

for each partner solution a docker-compose and corresponding otel-configuration file are provided

we need to create required API keys in the partner-solution before running these files.
docker-compose -f newrelic-docker-compose.yml up