### PR TITLE
Om 100

### DIFF
--- a/config/grafana/dashboards/alertsview.json
+++ b/config/grafana/dashboards/alertsview.json
@@ -70,12 +70,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "dark-green",
-                "value": null
-              },
-              {
                 "color": "#750310",
-                "value": 1
+                "value": null
               }
             ]
           }
@@ -112,7 +108,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count(ALERTS{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\", severity=~\"critical\", alertstate=~\"$state|$^\"}) ",
+          "expr": "count(ALERTS{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", severity=~\"critical\", alertstate=~\"$state\"}) ",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
@@ -133,7 +129,7 @@
             "mode": "thresholds"
           },
           "mappings": [],
-          "noValue": "0",
+          "noValue": "None",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -175,7 +171,7 @@
             "uid": "${DS_AEROSPIKE_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(ALERTS{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\", severity=~\"error\", alertstate=~\"$state\"}) ",
+          "expr": "count(ALERTS{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", severity=~\"error\", alertstate=~\"$state\"}) ",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -237,7 +233,7 @@
             "uid": "${DS_AEROSPIKE_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(ALERTS{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\", severity=~\"warn\", alertstate=~\"$state\"}) ",
+          "expr": "count(ALERTS{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", severity=~\"warn\", alertstate=~\"$state\"}) ",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -303,7 +299,7 @@
             "uid": "${DS_AEROSPIKE_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(ALERTS{job=\"$job_name\", cluster_name=~\"$cluster_name|$^\", service=~\"$node|$^\", severity=~\"info\", alertstate=~\"$state\"}) ",
+          "expr": "count(ALERTS{job=\"$job_name\", cluster_name=~\"$cluster_name\", service=~\"$node|$^\", severity=~\"info\", alertstate=~\"$state\"}) ",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -493,7 +489,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "ALERTS{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\", severity=~\"critical\", alertstate=~\"$state|$^\",}",
+          "expr": "ALERTS{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", severity=~\"critical\", alertstate=~\"$state\",}",
           "format": "table",
           "instant": true,
           "legendFormat": "{{severity}}",
@@ -535,8 +531,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "#FA6400",
-                    "value": null
+                    "color": "#FA6400"
                   }
                 ]
               }
@@ -692,7 +687,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "ALERTS{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\", severity=\"error\", alertstate=~\"$state|$^\",}",
+              "expr": "ALERTS{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", severity=\"error\", alertstate=~\"$state\",}",
               "format": "table",
               "instant": true,
               "legendFormat": "{{severity}}",
@@ -738,8 +733,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "dark-yellow",
-                    "value": null
+                    "color": "dark-yellow"
                   }
                 ]
               }
@@ -895,7 +889,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "ALERTS{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\", severity=\"warn\", alertstate=~\"$state|$^\",}",
+              "expr": "ALERTS{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", severity=\"warn\", alertstate=~\"$state\",}",
               "format": "table",
               "instant": true,
               "legendFormat": "{{severity}}",
@@ -1118,7 +1112,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "ALERTS{job=\"$job_name\", cluster_name=~\"$cluster|$^\", service=~\"$node|$^\", severity=~\"info\", alertstate=~\"$state|$^\"}",
+          "expr": "ALERTS{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", severity=~\"info\", alertstate=~\"$state\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "{{severity}}",
@@ -1275,6 +1269,6 @@
   "timezone": "",
   "title": "Alerts View",
   "uid": "hP_Uhx94k",
-  "version": 5,
+  "version": 7,
   "weekStart": ""
 }

--- a/config/grafana/dashboards/geoview.json
+++ b/config/grafana/dashboards/geoview.json
@@ -1,4 +1,15 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_AEROSPIKE_PROMETHEUS",
+      "label": "Aerospike Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
   "__requires": [
     {
       "type": "panel",
@@ -10,13 +21,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "9.3.2"
+      "version": "10.0.2"
     },
     {
       "type": "panel",
       "id": "grafana-polystat-panel",
       "name": "Polystat",
-      "version": "2.0.7"
+      "version": "2.0.9"
     },
     {
       "type": "datasource",
@@ -291,7 +302,7 @@
           "zoom": 1
         }
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -381,7 +392,7 @@
         },
         "textMode": "value"
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -457,7 +468,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -584,7 +595,7 @@
         "tooltipSecondarySortByField": "value",
         "tooltipSecondarySortDirection": 1
       },
-      "pluginVersion": "2.0.7",
+      "pluginVersion": "2.0.9",
       "targets": [
         {
           "datasource": {
@@ -664,7 +675,7 @@
         },
         "textMode": "name"
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -721,7 +732,8 @@
                 "value": 300
               }
             ]
-          }
+          },
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -746,7 +758,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -764,7 +776,7 @@
           "refId": "xdr_lag"
         }
       ],
-      "title": "XDR",
+      "title": "XDR Lag",
       "type": "stat"
     },
     {
@@ -828,7 +840,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -865,7 +877,7 @@
   ],
   "refresh": "1m",
   "revision": 1,
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -891,6 +903,10 @@
       },
       {
         "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_AEROSPIKE_PROMETHEUS}"
+        },
         "definition": "label_values(aerospike_node_stats_uptime,job)",
         "hide": 0,
         "includeAll": false,
@@ -966,6 +982,6 @@
   "timezone": "",
   "title": "Multi Cluster View",
   "uid": "03SlXxlVz",
-  "version": 6,
+  "version": 2,
   "weekStart": ""
 }

--- a/config/grafana/dashboards/geoview.json
+++ b/config/grafana/dashboards/geoview.json
@@ -1,15 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_AEROSPIKE_PROMETHEUS",
-      "label": "Aerospike Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
   "__requires": [
     {
       "type": "panel",
@@ -21,13 +10,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "10.0.2"
+      "version": "9.3.2"
     },
     {
       "type": "panel",
       "id": "grafana-polystat-panel",
       "name": "Polystat",
-      "version": "2.0.9"
+      "version": "2.0.7"
     },
     {
       "type": "datasource",
@@ -302,7 +291,7 @@
           "zoom": 1
         }
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "9.3.2",
       "targets": [
         {
           "datasource": {
@@ -311,7 +300,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count by (latitude, longitude, cluster_name) (ALERTS{cluster_name!=\"\"}) * -1\nor\ncount by (latitude, longitude, cluster_name) (aerospike_node_up)\n",
+          "expr": "count by (latitude, longitude, cluster_name) (ALERTS{cluster_name!=\"\", severity=~\"warn|info|error|critical\"}) * -1\nor\ncount by (latitude, longitude, cluster_name) (aerospike_node_up)\n",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -392,7 +381,7 @@
         },
         "textMode": "value"
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "9.3.2",
       "targets": [
         {
           "datasource": {
@@ -426,7 +415,7 @@
             {
               "targetBlank": true,
               "title": "Cluster View",
-              "url": "/d/0bMepuvZz/alerts?orgId=1&refresh=1m&${__all_variables}"
+              "url": "/d/hP_Uhx94k/alerts-view?orgId=1&${__all_variables}"
             }
           ],
           "mappings": [],
@@ -468,7 +457,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "9.3.2",
       "targets": [
         {
           "datasource": {
@@ -477,7 +466,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count(ALERTS{cluster_name=~\"$cluster\"}) or vector(0)",
+          "expr": "count(ALERTS{cluster_name=~\"$cluster\", severity=~\"$severity\"}) or vector(0)",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -486,7 +475,7 @@
           "refId": "alerts"
         }
       ],
-      "title": "Alerts",
+      "title": "Alerts - $severity",
       "type": "stat"
     },
     {
@@ -595,7 +584,7 @@
         "tooltipSecondarySortByField": "value",
         "tooltipSecondarySortDirection": 1
       },
-      "pluginVersion": "2.0.9",
+      "pluginVersion": "2.0.7",
       "targets": [
         {
           "datasource": {
@@ -604,7 +593,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count by (service,cluster_name) (ALERTS{cluster_name=\"$cluster\", service!=\"\"}) * -1\nor\ncount by (service,cluster_name) (aerospike_node_up{ cluster_name=\"$cluster\"})",
+          "expr": "count by (service,cluster_name) (ALERTS{cluster_name=\"$cluster\", service!=\"\",severity=~\"$severity\"}) * -1\nor\ncount by (service,cluster_name) (aerospike_node_up{ cluster_name=\"$cluster\"})",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -675,7 +664,7 @@
         },
         "textMode": "name"
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "9.3.2",
       "targets": [
         {
           "datasource": {
@@ -684,7 +673,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count by (ns) (ALERTS{cluster_name=\"$cluster\", ns=~\"..*\"}) * -1 \nor\nsum by (ns) (aerospike_namespace_objects{cluster_name=\"$cluster\"} )",
+          "expr": "count by (ns) (ALERTS{cluster_name=\"$cluster\", ns=~\"..*\", severity=~\"$severity|$^\"}) * -1 \nor\nsum by (ns) (aerospike_namespace_objects{cluster_name=\"$cluster\"} )",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -711,11 +700,11 @@
             {
               "targetBlank": true,
               "title": "Cluster View",
-              "url": "/d/dR0dDRHWz/cluster-overview?orgId=1&refresh=1m&${cluster:queryparam}"
+              "url": "/d/hU_4PTqWk/xdr-view-aerospike-5-0-only?orgId=1&refresh=1m&${cluster:queryparam}"
             }
           ],
           "mappings": [],
-          "noValue": "NA",
+          "noValue": "N/A",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -733,7 +722,7 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -751,14 +740,14 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "last"
           ],
           "fields": "",
           "values": false
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "9.3.2",
       "targets": [
         {
           "datasource": {
@@ -794,11 +783,11 @@
             {
               "targetBlank": true,
               "title": "Cluster View",
-              "url": "/d/dR0dDRHWz/cluster-overview?orgId=1&refresh=1m&${cluster:queryparam}"
+              "url": "/d/ZoeGW1DBk/latency-view?orgId=1&refresh=1m&${cluster:queryparam}"
             }
           ],
           "mappings": [],
-          "noValue": "Select a cluster",
+          "noValue": "N/A",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -840,7 +829,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "9.3.2",
       "targets": [
         {
           "datasource": {
@@ -877,7 +866,7 @@
   ],
   "refresh": "1m",
   "revision": 1,
-  "schemaVersion": 38,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -971,6 +960,29 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_AEROSPIKE_PROMETHEUS}"
+        },
+        "definition": "label_values(ALERTS{job=\"$job_name\",},severity)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Alert Severity",
+        "multi": true,
+        "name": "severity",
+        "options": [],
+        "query": {
+          "query": "label_values(ALERTS{job=\"$job_name\",},severity)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/^[A-Za-z]+$/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       }
     ]
   },
@@ -982,6 +994,6 @@
   "timezone": "",
   "title": "Multi Cluster View",
   "uid": "03SlXxlVz",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/config/grafana/dashboards/uniquedata.json
+++ b/config/grafana/dashboards/uniquedata.json
@@ -22,6 +22,12 @@
       "id": "stat",
       "name": "Stat",
       "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
     }
   ],
   "annotations": {
@@ -54,19 +60,6 @@
   "liveNow": false,
   "panels": [
     {
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "panels": [],
-      "title": "Unique Data Usage",
-      "type": "row"
-    },
-    {
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_AEROSPIKE_PROMETHEUS}"
@@ -92,10 +85,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 5,
         "w": 12,
         "x": 0,
-        "y": 1
+        "y": 0
       },
       "id": 4,
       "links": [],
@@ -129,6 +122,89 @@
         },
         {
           "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AEROSPIKE_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "(sum( # Running individual exporter for each node in a cluster\n    (avg by (ns) ( aerospike_namespace_ns_cluster_size {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} ))\n    == bool \n    (count by (ns) (aerospike_namespace_ns_cluster_size {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} ))\n)> bool 0)\n* # migration check with RX metric\n(sum((sum by (ns) (aerospike_namespace_migrate_rx_partitions_remaining + aerospike_namespace_migrate_tx_partitions_remaining) != bool 0))\n== bool 0)\n* # Consistent Effective Replication factor across all nodes\n(sum(\n    min by (ns) (aerospike_namespace_effective_replication_factor {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) \n    == bool \n    max by (ns) (aerospike_namespace_effective_replication_factor {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})\n) > bool 0)",
+          "hide": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "QR_RULE_CAN_SHOW"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AEROSPIKE_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum (aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
+          "format": "time_series",
+          "hide": true,
+          "instant": false,
+          "legendFormat": "All Master Objects",
+          "range": true,
+          "refId": "Q_MEMORY_OBJECTS"
+        }
+      ],
+      "title": "Cluster - All Master Objects",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_AEROSPIKE_PROMETHEUS}"
+      },
+      "description": "Display Unique Data Utilization across all  namespaces",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 27,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.2",
+      "targets": [
+        {
+          "datasource": {
             "type": "__expr__",
             "uid": "__expr__"
           },
@@ -155,58 +231,160 @@
             "uid": "${DS_AEROSPIKE_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(sum((sum((sum ( (((aerospike_namespace_memory_used_data_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} + aerospike_namespace_memory_used_index_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})\nunless # we pick namespace which are in memory but not using Disk or Pmem\n(aerospike_namespace_device_used_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} or aerospike_namespace_pmem_used_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} )\n) \n/aerospike_namespace_effective_replication_factor {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}\n) \n- ( # begin calculate the header byte size 39bytes if as-version>=6 and 34 if as-version<6\n   sum (\n      aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n      group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^4.*\"}*35) \n      or\n      aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n      group_left(build) (\n        aerospike_node_up{job=\"$job_name\", build=~\"^5.*\"}*35) \n      or\n      aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n      group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build!~\"^5.*\"}*39) ) \n   by (job, cluster_name, instance, service,ns) \n  ) # end of header-byte calculation by aerospike version\n) by (service, ns)) ) by (ns))) \n+\nsum (\n  ( # device-used-bytes + pmem-used-bytes\n    ( # sum disk device used bytes\n      ( sum by (ns) (aerospike_namespace_device_used_bytes{job=\"$job_name\"}) /\n      ( sum by (ns) ( (aerospike_namespace_device_compression_ratio{job=\"$job_name\"} )) \n      *\n      avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\"} ))\n    )\n  or\n    ( sum by (ns) (aerospike_namespace_device_used_bytes{job=\"$job_name\"}) /\n    ( avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\"} ))\n  )\n) # end devide-used-bytes\nor\n( \n    ( sum by (ns) (aerospike_namespace_pmem_used_bytes{job=\"$job_name\"}) /\n    ( sum by (ns) ( (aerospike_namespace_pmem_compression_ratio{job=\"$job_name\"} ))  \n      * avg by (ns) (aerospike_namespace_effective_replication_factor{job=\"$job_name\"}) ))\nor\n    ( sum by (ns) (aerospike_namespace_pmem_used_bytes{job=\"$job_name\"}) /\n    ( avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\"}) ))     \n)\n)\n- ( # begin calculate the header byte size 39bytes if as-version>=6 and 34 if as-version<6\n   sum (\n      aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n      group_left(build) (\n        aerospike_node_up{job=\"$job_name\", build=~\"^4.*\"}*35) \n      or\n      aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n      group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^5.*\"}*35) \n      or\n      aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n      group_left(build) (\n        aerospike_node_up{job=\"$job_name\", build!~\"^5.*\"}*39) ) \n   by (ns)\n) # end of header-byte calculation by aerospike version\n) # end of disk+pmem used bytes\n\n) # end paranthesis for whole sum",
+          "expr": "(sum((sum((sum ( (((aerospike_namespace_memory_used_data_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} + aerospike_namespace_memory_used_index_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})\nunless # we pick namespace which are in memory but not using Disk or Pmem\n(aerospike_namespace_device_used_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} or aerospike_namespace_pmem_used_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} )\n) \n/aerospike_namespace_effective_replication_factor {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}\n) \n- on (job, cluster_name, instance, service,ns) ( # begin calculate the header byte size 39bytes if as-version>=6 and 34 if as-version<6\n   sum (\n      aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} * on (job, cluster_name, service) \n      group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^4.*\"}*35) \n      or\n      aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} * on (job, cluster_name, service) \n      group_left(build) (\n        aerospike_node_up{job=\"$job_name\", build=~\"^5.*\"}*35) \n      or\n      aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} * on (job, cluster_name, service) \n      group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build!~\"^5.*\"}*39) ) \n   by (job, cluster_name, instance, service,ns) \n  ) # end of header-byte calculation by aerospike version\n) by (service, ns)) or vector(0) ) by (ns))) \n+ on (job, cluster_name, instance, service,ns)\nsum (\n  ( # device-used-bytes + pmem-used-bytes\n    ( # sum disk device used bytes\n      ( sum by (ns) (aerospike_namespace_device_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) /\n      ( sum by (ns) ( (aerospike_namespace_device_compression_ratio{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} )) \n      *\n      avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} ))\n    )\n  or\n    ( sum by (ns) (aerospike_namespace_device_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) /\n    ( avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} ))\n  )\n) # end devide-used-bytes\nor\n( \n    ( sum by (ns) (aerospike_namespace_pmem_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) /\n    ( sum by (ns) ( (aerospike_namespace_pmem_compression_ratio{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} ))  \n      * avg by (ns) (aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) ))\nor\n    ( sum by (ns) (aerospike_namespace_pmem_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) /\n    ( avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) ))     \n)\n)\n- on (job, cluster_name, instance, service,ns) ( # begin calculate the header byte size 39bytes if as-version>=6 and 34 if as-version<6\n   sum (\n      aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} * on (job, cluster_name, service) \n      group_left(build) (\n        aerospike_node_up{job=\"$job_name\", build=~\"^4.*\"}*35) \n      or\n      aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} * on (job, cluster_name, service) \n      group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^5.*\"}*35) \n      or\n      aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} * on (job, cluster_name, service) \n      group_left(build) (\n        aerospike_node_up{job=\"$job_name\", build!~\"^5.*\"}*39) ) \n   by (ns)\n) # end of header-byte calculation by aerospike version\nor vector(0)) # end of disk+pmem used bytes\n\n) # end paranthesis for whole sum",
           "hide": true,
           "legendFormat": "Unique Data Bytes",
           "range": true,
           "refId": "Q_USAGE_BYTE"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_AEROSPIKE_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum (aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})",
-          "format": "time_series",
-          "hide": true,
-          "instant": false,
-          "legendFormat": "All Master Objects",
-          "range": true,
-          "refId": "Q_MEMORY_OBJECTS"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_AEROSPIKE_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum (aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})\n* # above query should work only if the below condition satisfy\n(sum( # Running individual exporter for each node in a cluster\n    (avg by (ns) ( aerospike_namespace_ns_cluster_size {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} ))\n    == bool \n    (count by (ns) (aerospike_namespace_ns_cluster_size {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} ))\n)> bool 0)\n* # migration check with RX metric\n(sum((sum by (ns) (aerospike_namespace_migrate_rx_partitions_remaining + aerospike_namespace_migrate_tx_partitions_remaining) != bool 0))\n== bool 0)\n* # Consistent Effective Replication factor across all nodes\n(sum(\n    min by (ns) (aerospike_namespace_effective_replication_factor {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) \n    == bool \n    max by (ns) (aerospike_namespace_effective_replication_factor {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})\n) > bool 0)",
-          "format": "time_series",
-          "hide": true,
-          "instant": false,
-          "legendFormat": "All Master Objects",
-          "range": true,
-          "refId": "Master Object with Rules"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_AEROSPIKE_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "(sum((sum((sum ( (((aerospike_namespace_memory_used_data_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} + aerospike_namespace_memory_used_index_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})\nunless\naerospike_namespace_device_used_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}\n) \n/aerospike_namespace_effective_replication_factor {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}\n) \n- ( # begin calculate the header byte size 39bytes if as-version>=6 and 34 if as-version<6\n   sum (\n      aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n      group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^4.*\"}*35) \n      or\n      aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n      group_left(build) (\n        aerospike_node_up{job=\"$job_name\", build=~\"^5.*\"}*35) \n      or\n      aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n      group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build!~\"^5.*\"}*39) ) \n   by (job, cluster_name, instance, service,ns) \n  ) # end of header-byte calculation by aerospike version\n) by (service, ns)) ) by (ns))) \n+\nsum (\n  (\n( \n sum by (ns) (aerospike_namespace_device_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) /\n( sum by (ns) ( (aerospike_namespace_device_compression_ratio{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} \n)  ) *\navg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) )\n)\nor\n( \n sum by (ns) (aerospike_namespace_device_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) /\n( \navg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) )\n)\n)\n- ( # begin calculate the header byte size 39bytes if as-version>=6 and 34 if as-version<6\n   sum (\n      aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n      group_left(build) (\n        aerospike_node_up{job=\"$job_name\", build=~\"^4.*\"}*35) !=0\n      or\n      aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n      group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^5.*\"}*35) !=0\n      or\n      aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n      group_left(build) (\n        aerospike_node_up{job=\"$job_name\", build=~\"^6.*\"}*39) !=0) \n   by (ns)\n) # end of header-byte calculation by aerospike version\n)\n)\n* # above query should work only if the below condition satisfy\n(sum( # Running individual exporter for each node in a cluster\n    (avg by (ns) ( aerospike_namespace_ns_cluster_size {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} ))\n    == bool \n    (count by (ns) (aerospike_namespace_ns_cluster_size {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} ))\n)> bool 0)\n* # migration check with RX metric\n(sum((sum by (ns) (aerospike_namespace_migrate_rx_partitions_remaining + aerospike_namespace_migrate_tx_partitions_remaining) != bool 0))\n== bool 0)\n* # Consistent Effective Replication factor across all nodes\n(sum(\n    min by (ns) (aerospike_namespace_effective_replication_factor {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) \n    == bool \n    max by (ns) (aerospike_namespace_effective_replication_factor {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})\n) > bool 0)",
-          "hide": true,
-          "legendFormat": "Unique Data Bytes",
-          "range": true,
-          "refId": "Usage Bytes with Rules"
         }
       ],
-      "title": "Cluster - Unique Data Usage ",
+      "title": "Cluster - Unique Data Bytes ",
       "transformations": [],
       "type": "stat"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 29,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AEROSPIKE_PROMETHEUS}"
+          },
+          "description": "Display Unique Data Utilization across all  namespaces",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "#299c46"
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 6
+          },
+          "id": 36,
+          "interval": "5m",
+          "links": [],
+          "maxDataPoints": 150,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.3.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "__expr__",
+                "uid": "__expr__"
+              },
+              "expression": "$Q_USAGE_BYTE * $QR_RULE_CAN_SHOW",
+              "hide": false,
+              "refId": "Unique Data Bytes",
+              "type": "math"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_AEROSPIKE_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "(sum( # Running individual exporter for each node in a cluster\n    (avg by (ns) ( aerospike_namespace_ns_cluster_size {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} ))\n    == bool \n    (count by (ns) (aerospike_namespace_ns_cluster_size {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} ))\n)> bool 0)\n* # migration check with RX metric\n(sum((sum by (ns) (aerospike_namespace_migrate_rx_partitions_remaining + aerospike_namespace_migrate_tx_partitions_remaining) != bool 0))\n== bool 0)\n* # Consistent Effective Replication factor across all nodes\n(sum(\n    min by (ns) (aerospike_namespace_effective_replication_factor {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) \n    == bool \n    max by (ns) (aerospike_namespace_effective_replication_factor {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})\n) > bool 0)",
+              "hide": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "QR_RULE_CAN_SHOW"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_AEROSPIKE_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "(sum((sum((sum ( (((aerospike_namespace_memory_used_data_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} + aerospike_namespace_memory_used_index_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})\nunless # we pick namespace which are in memory but not using Disk or Pmem\n(aerospike_namespace_device_used_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} or aerospike_namespace_pmem_used_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} )\n) \n/aerospike_namespace_effective_replication_factor {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}\n) \n- on (job, cluster_name, instance, service,ns) ( # begin calculate the header byte size 39bytes if as-version>=6 and 34 if as-version<6\n   sum (\n      aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} * on (job, cluster_name, service) \n      group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^4.*\"}*35) \n      or\n      aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} * on (job, cluster_name, service) \n      group_left(build) (\n        aerospike_node_up{job=\"$job_name\", build=~\"^5.*\"}*35) \n      or\n      aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} * on (job, cluster_name, service) \n      group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build!~\"^5.*\"}*39) ) \n   by (job, cluster_name, instance, service,ns) \n  ) # end of header-byte calculation by aerospike version\n) by (service, ns)) or vector(0) ) by (ns))) \n+ on (job, cluster_name, instance, service,ns)\nsum (\n  ( # device-used-bytes + pmem-used-bytes\n    ( # sum disk device used bytes\n      ( sum by (ns) (aerospike_namespace_device_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) /\n      ( sum by (ns) ( (aerospike_namespace_device_compression_ratio{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} )) \n      *\n      avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} ))\n    )\n  or\n    ( sum by (ns) (aerospike_namespace_device_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) /\n    ( avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} ))\n  )\n) # end devide-used-bytes\nor\n( \n    ( sum by (ns) (aerospike_namespace_pmem_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) /\n    ( sum by (ns) ( (aerospike_namespace_pmem_compression_ratio{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} ))  \n      * avg by (ns) (aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) ))\nor\n    ( sum by (ns) (aerospike_namespace_pmem_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) /\n    ( avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) ))     \n)\n)\n- on (job, cluster_name, instance, service,ns) ( # begin calculate the header byte size 39bytes if as-version>=6 and 34 if as-version<6\n   sum (\n      aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} * on (job, cluster_name, service) \n      group_left(build) (\n        aerospike_node_up{job=\"$job_name\", build=~\"^4.*\"}*35) \n      or\n      aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} * on (job, cluster_name, service) \n      group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^5.*\"}*35) \n      or\n      aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} * on (job, cluster_name, service) \n      group_left(build) (\n        aerospike_node_up{job=\"$job_name\", build!~\"^5.*\"}*39) ) \n   by (ns)\n) # end of header-byte calculation by aerospike version\nor vector(0)) # end of disk+pmem used bytes\n\n) # end paranthesis for whole sum",
+              "hide": true,
+              "legendFormat": "Unique Data Bytes",
+              "range": true,
+              "refId": "Q_USAGE_BYTE"
+            }
+          ],
+          "title": "Cluster - Unique Data Usage ",
+          "transformations": [],
+          "type": "timeseries"
+        }
+      ],
+      "title": "Historical - Usage Bytes",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 2,
+      "panels": [],
+      "title": "Unique Data Usage",
+      "type": "row"
     },
     {
       "datasource": {
@@ -224,8 +402,12 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#299c46",
+                "color": "#6a9f78",
                 "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
               }
             ]
           },
@@ -235,19 +417,19 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 8,
+        "w": 12,
         "x": 0,
-        "y": 5
+        "y": 7
       },
       "id": 6,
       "links": [],
       "maxDataPoints": 100,
-      "maxPerRow": 4,
+      "maxPerRow": 2,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "center",
-        "orientation": "auto",
+        "orientation": "vertical",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -260,7 +442,7 @@
       },
       "pluginVersion": "9.3.2",
       "repeat": "namespace",
-      "repeatDirection": "v",
+      "repeatDirection": "h",
       "targets": [
         {
           "datasource": {
@@ -271,10 +453,10 @@
           "exemplar": false,
           "expr": "(sum (aerospike_namespace_master_objects{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}) by (ns) )  ",
           "hide": false,
-          "instant": true,
+          "instant": false,
           "interval": "",
           "legendFormat": "master objects - ",
-          "range": false,
+          "range": true,
           "refId": "master objects"
         },
         {
@@ -303,7 +485,7 @@
             "uid": "__expr__"
           },
           "expression": "$Q_PMEM_DISK_USAGE * $QR_RULE_CAN_SHOW",
-          "hide": true,
+          "hide": false,
           "refId": "on Pmem -",
           "type": "math"
         },
@@ -326,13 +508,13 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "((\n (sum by (ns) (aerospike_namespace_device_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} / aerospike_namespace_device_compression_ratio{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})\n ) /\n(avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}))\nOR\n (sum by (ns) (aerospike_namespace_device_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} )\n ) /\n(avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}))\n)- ( # begin calculate the header byte size 39bytes if as-version>=6 and 34 if as-version<6\n   sum (\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^4.*\"}*35) !=0\n    or\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^5.*\"}*35) !=0\n    or\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^6.*\"}*39) !=0) by (ns)\n   ) # end calculation of header-byte by server-version\n)",
+          "expr": "((\n (sum by (ns) (aerospike_namespace_device_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} / aerospike_namespace_device_compression_ratio{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})\n ) /\n(avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}))\nOR\n (sum by (ns) (aerospike_namespace_device_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} )\n ) /\n(avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}))\n)- on (job, cluster_name, instance, service,ns)  ( # begin calculate the header byte size 39bytes if as-version>=6 and 34 if as-version<6\n   sum (\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^4.*\"}*35) !=0\n    or\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^5.*\"}*35) !=0\n    or\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^6.*\"}*39) !=0) by (ns)\n   ) # end calculation of header-byte by server-version\n)",
           "format": "time_series",
           "hide": true,
-          "instant": true,
+          "instant": false,
           "interval": "",
           "legendFormat": "{{service}} {{ns}} - on Disk ",
-          "range": false,
+          "range": true,
           "refId": "Q_DISK_USAGE"
         },
         {
@@ -342,13 +524,13 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "((\n (sum by (ns) (aerospike_namespace_pmem_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} / aerospike_namespace_pmem_compression_ratio{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})\n ) /\n(avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}))\nOR\n (sum by (ns) (aerospike_namespace_pmem_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} )\n ) /\n(avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}))\n)- ( # begin calculate the header byte size 39bytes if as-version>=6 and 34 if as-version<6\n   sum (\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^4.*\"}*35) !=0\n    or\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^5.*\"}*35) !=0\n    or\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^6.*\"}*39) !=0) by (ns)\n   ) # end calculation of header-byte by server-version\n)",
+          "expr": "((\n (sum by (ns) (aerospike_namespace_pmem_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} / aerospike_namespace_pmem_compression_ratio{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})\n ) /\n(avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}))\nOR\n (sum by (ns) (aerospike_namespace_pmem_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} )\n ) /\n(avg by (ns) ( aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}))\n)- on (job, cluster_name, instance, service,ns) ( # begin calculate the header byte size 39bytes if as-version>=6 and 34 if as-version<6\n   sum (\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^4.*\"}*35) !=0\n    or\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^5.*\"}*35) !=0\n    or\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^6.*\"}*39) !=0) by (ns)\n   ) # end calculation of header-byte by server-version\n)",
           "format": "time_series",
           "hide": true,
-          "instant": true,
+          "instant": false,
           "interval": "",
           "legendFormat": "{{service}} {{ns}} - on Disk ",
-          "range": false,
+          "range": true,
           "refId": "Q_PMEM_DISK_USAGE"
         },
         {
@@ -358,7 +540,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "((sum((sum ( ((((aerospike_namespace_memory_used_data_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} + aerospike_namespace_memory_used_index_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})  )\nunless # We pick up namespace which use memory, but not Disk or Pmem\n(aerospike_namespace_device_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} or aerospike_namespace_pmem_used_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})\n) \n/aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}\n) \n- ( # calculate the header byte size 39bytes if as-version>=6 and 34 if as-version<6\n  sum (\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^4.*\"}*35) \n    or\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^5.*\"}*35) \n    or\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build!~\"^5.*\"}*39) ) \n  by (job, cluster_name, instance, service,ns)\n  ) \n) by (service, ns)) ) by (ns))\n)",
+          "expr": "((sum((sum ( ((((aerospike_namespace_memory_used_data_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} + aerospike_namespace_memory_used_index_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})  )\nunless # We pick up namespace which use memory, but not Disk or Pmem\n(aerospike_namespace_device_used_bytes{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"} or aerospike_namespace_pmem_used_bytes {job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"})\n) \n/aerospike_namespace_effective_replication_factor{job=\"$job_name\", cluster_name=~\"$cluster\", service=~\"$node|$^\", ns=~\"$namespace|$^\"}\n) \n- on (job, cluster_name, instance, service,ns) \n  ( # calculate the header byte size 39bytes if as-version>=6 and 34 if as-version<6\n  sum (\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^4.*\"}*35) \n    or\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build=~\"^5.*\"}*35) \n    or\n    aerospike_namespace_master_objects{job=\"$job_name\"} * on (job, cluster_name, service) \n    group_left(build) ( \n        aerospike_node_up{job=\"$job_name\", build!~\"^5.*\"}*39) ) \n  by (job, cluster_name, instance, service,ns)\n  ) \n) by (service, ns)) ) by (ns))\n)",
           "hide": true,
           "instant": false,
           "legendFormat": "{{ns}} - in Memory",
@@ -376,6 +558,7 @@
       "type": "stat"
     }
   ],
+  "refresh": false,
   "schemaVersion": 37,
   "style": "dark",
   "tags": [],
@@ -458,7 +641,7 @@
         "hide": 0,
         "includeAll": true,
         "label": "node",
-        "multi": false,
+        "multi": true,
         "name": "node",
         "options": [],
         "query": {
@@ -481,7 +664,7 @@
         "description": "displays the list of all namespaces configured across all  aerospike clusters ",
         "hide": 0,
         "includeAll": true,
-        "multi": false,
+        "multi": true,
         "name": "namespace",
         "options": [],
         "query": {
@@ -497,7 +680,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-12h",
     "to": "now"
   },
   "timepicker": {},

--- a/config/grafana/provisioning/datasources/all.yaml
+++ b/config/grafana/provisioning/datasources/all.yaml
@@ -15,7 +15,7 @@ datasources:
     # orgId: 1
     url: http://alertmanager:9093
     editable: true
-    isDefault: false
+    isDefault: true
 
   - name: "Aerospike Prometheus"
     type: prometheus


### PR DESCRIPTION
unique-data view - fixed bugs 1) unique-data-bytes are not displayed when geo-location is added and 2) query to honour selected namespaces 
and 3) added a historical time series panel
alerts view - fixed display colour and show alerts specific to selection criteria
multi-cluster-view: fixed Grafana version to 9.x, XDR and Latencies point to respective dashboards (instead of cluster-view dashboard). added enhancement to filter using alert-severity
