### PR TITLE
Fix summary in labels instead of annotations

### DIFF
--- a/config/prometheus/aerospike_connector_rules.yml
+++ b/config/prometheus/aerospike_connector_rules.yml
@@ -26,8 +26,8 @@ groups:
     for: 30s
     labels:
       severity: critical
-      summary: "Request Errors crossed 1% of the total requests processed in xdr_proxy connector instance {{ $labels.instance }} of cluster {{$labels.cluster_name}}"
     annotations:
+      summary: "Request Errors crossed 1% of the total requests processed in xdr_proxy connector instance {{ $labels.instance }} of cluster {{$labels.cluster_name}}"
       description: "Request Errors crossed 1% of the total requests processed in xdr_proxy connector instance {{ $labels.instance }} of cluster {{$labels.cluster_name}}"
       
   - alert: AerospikeConnectorJvmProcessCPU


### PR DESCRIPTION
`AerospikeConnectorErrors` alert `summary` was in the `labels` section for some reason, while all other alerts it is under `annotations`.